### PR TITLE
feat: unified bin creation flow with QR code and photo storage

### DIFF
--- a/binthere/Models/Bin.swift
+++ b/binthere/Models/Bin.swift
@@ -8,6 +8,8 @@ final class Bin {
     var binDescription: String = ""
     var location: String = ""
     var createdAt: Date = Date()
+    var qrCodeImagePath: String?
+    var contentImagePaths: [String] = []
 
     var zone: Zone?
 

--- a/binthere/Views/Bins/AddBinView.swift
+++ b/binthere/Views/Bins/AddBinView.swift
@@ -125,17 +125,38 @@ struct AddBinView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 200, height: 200)
+
+                HStack(spacing: 16) {
+                    ShareLink(
+                        item: Image(uiImage: qrImage),
+                        preview: SharePreview("QR Code: \(bin.name)", image: Image(uiImage: qrImage))
+                    ) {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button(action: { printQRCode(qrImage) }) {
+                        Label("Print", systemImage: "printer")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
             }
 
-            Text("Print this and stick it on your bin")
+            Text("Stick it on your bin so you can scan it later")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
-
-            Text(bin.id.uuidString)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                .textSelection(.enabled)
         }
+    }
+
+    private func printQRCode(_ image: UIImage) {
+        let printInfo = UIPrintInfo(dictionary: nil)
+        printInfo.jobName = "QR Code: \(name)"
+        printInfo.outputType = .photo
+
+        let printer = UIPrintInteractionController.shared
+        printer.printInfo = printInfo
+        printer.printingItem = image
+        printer.present(animated: true)
     }
 
     private var photoSection: some View {

--- a/binthere/Views/Bins/AddBinView.swift
+++ b/binthere/Views/Bins/AddBinView.swift
@@ -17,6 +17,7 @@ struct AddBinView: View {
     @State private var showingImagePicker = false
     @State private var analysisService = ImageAnalysisService()
     @State private var hasAnalyzed = false
+    @State private var showingAddItem = false
 
     enum CreationStep {
         case details
@@ -105,6 +106,11 @@ struct AddBinView: View {
         .sheet(isPresented: $showingImagePicker) {
             ImagePickerView(selectedImage: $contentPhoto, sourceType: .photoLibrary)
         }
+        .sheet(isPresented: $showingAddItem) {
+            if let bin = createdBin {
+                AddItemView(bin: bin)
+            }
+        }
     }
 
     private func qrCodeSection(for bin: Bin) -> some View {
@@ -178,6 +184,16 @@ struct AddBinView: View {
                 }
                 .padding(.horizontal)
             }
+
+            Divider()
+                .padding(.horizontal)
+
+            Button(action: { showingAddItem = true }) {
+                Label("Add Items Manually", systemImage: "plus.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .padding(.horizontal)
         }
     }
 

--- a/binthere/Views/Bins/AddBinView.swift
+++ b/binthere/Views/Bins/AddBinView.swift
@@ -6,50 +6,330 @@ struct AddBinView: View {
     @Environment(\.dismiss) private var dismiss
     @Query(sort: \Zone.name) private var zones: [Zone]
 
+    @State private var step: CreationStep = .details
     @State private var name = ""
     @State private var binDescription = ""
     @State private var location = ""
     @State private var selectedZone: Zone?
+    @State private var createdBin: Bin?
+    @State private var contentPhoto: UIImage?
+    @State private var showingCamera = false
+    @State private var showingImagePicker = false
+    @State private var analysisService = ImageAnalysisService()
+    @State private var hasAnalyzed = false
+
+    enum CreationStep {
+        case details
+        case qrAndPhoto
+        case aiResults
+    }
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section("Details") {
-                    TextField("Bin Name", text: $name)
-                    TextField("Description", text: $binDescription, axis: .vertical)
-                        .lineLimit(3...6)
-                    TextField("Location", text: $location)
-                }
-
-                Section("Zone") {
-                    Picker("Zone", selection: $selectedZone) {
-                        Text("None").tag(nil as Zone?)
-                        ForEach(zones) { zone in
-                            Text(zone.name).tag(zone as Zone?)
-                        }
-                    }
+            Group {
+                switch step {
+                case .details:
+                    detailsStep
+                case .qrAndPhoto:
+                    qrAndPhotoStep
+                case .aiResults:
+                    aiResultsStep
                 }
             }
-            .navigationTitle("New Bin")
+            .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    if step == .details {
+                        Button("Cancel") { dismiss() }
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") { saveBin() }
-                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                    confirmButton
                 }
             }
         }
     }
 
-    private func saveBin() {
-        let bin = Bin(name: name.trimmingCharacters(in: .whitespaces),
-                      binDescription: binDescription,
-                      location: location)
+    private var navigationTitle: String {
+        switch step {
+        case .details: "New Bin"
+        case .qrAndPhoto: "Set Up Bin"
+        case .aiResults: "Add Items"
+        }
+    }
+
+    // MARK: - Step 1: Details
+
+    private var detailsStep: some View {
+        Form {
+            Section("What's this bin?") {
+                TextField("Bin Name", text: $name)
+                TextField("Description (optional)", text: $binDescription, axis: .vertical)
+                    .lineLimit(3...6)
+                TextField("Location (optional)", text: $location)
+            }
+
+            Section("Zone") {
+                Picker("Zone", selection: $selectedZone) {
+                    Text("None").tag(nil as Zone?)
+                    ForEach(zones) { zone in
+                        Text(zone.name).tag(zone as Zone?)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Step 2: QR Code + Photo
+
+    private var qrAndPhotoStep: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // QR Code section
+                if let bin = createdBin {
+                    qrCodeSection(for: bin)
+                }
+
+                Divider()
+                    .padding(.horizontal)
+
+                // Photo section
+                photoSection
+            }
+            .padding(.vertical)
+        }
+        .sheet(isPresented: $showingCamera) {
+            ImagePickerView(selectedImage: $contentPhoto, sourceType: .camera)
+        }
+        .sheet(isPresented: $showingImagePicker) {
+            ImagePickerView(selectedImage: $contentPhoto, sourceType: .photoLibrary)
+        }
+    }
+
+    private func qrCodeSection(for bin: Bin) -> some View {
+        VStack(spacing: 12) {
+            Text("Your QR Code")
+                .font(.headline)
+
+            if let qrPath = bin.qrCodeImagePath,
+               let qrImage = ImageStorageService.loadImage(filename: qrPath) {
+                Image(uiImage: qrImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
+            }
+
+            Text("Print this and stick it on your bin")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Text(bin.id.uuidString)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var photoSection: some View {
+        VStack(spacing: 16) {
+            Text("Photo of Contents")
+                .font(.headline)
+
+            Text("Take a photo of what's in the bin. AI can identify items for you.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            if let photo = contentPhoto {
+                Image(uiImage: photo)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: 250)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.horizontal)
+
+                HStack(spacing: 16) {
+                    Button("Retake") {
+                        contentPhoto = nil
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("Analyze with AI") {
+                        analyzePhoto()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            } else {
+                HStack(spacing: 16) {
+                    Button(action: { showingCamera = true }) {
+                        Label("Camera", systemImage: "camera")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button(action: { showingImagePicker = true }) {
+                        Label("Library", systemImage: "photo")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    // MARK: - Step 3: AI Results
+
+    private var aiResultsStep: some View {
+        Group {
+            if analysisService.isAnalyzing {
+                VStack(spacing: 20) {
+                    Spacer()
+                    ProgressView()
+                        .scaleEffect(1.5)
+                    Text("Analyzing your bin contents...")
+                        .font(.headline)
+                    Text("AI is identifying items")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            } else if let error = analysisService.error {
+                VStack(spacing: 16) {
+                    Spacer()
+                    ContentUnavailableView(
+                        "Analysis Failed",
+                        systemImage: "exclamationmark.triangle",
+                        description: Text(error.localizedDescription)
+                    )
+                    Button("Try Again") { analyzePhoto() }
+                        .buttonStyle(.bordered)
+                    Button("Skip — I'll add items manually") { dismiss() }
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            } else {
+                List {
+                    Section {
+                        Text("Review what AI found. Edit or deselect anything that's off.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ForEach($analysisService.suggestedItems) { $suggestion in
+                        SuggestedItemRow(suggestion: $suggestion)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Confirm Button
+
+    @ViewBuilder
+    private var confirmButton: some View {
+        switch step {
+        case .details:
+            Button("Create Bin") { createBin() }
+                .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+        case .qrAndPhoto:
+            Button("Done") { dismiss() }
+        case .aiResults:
+            if !analysisService.isAnalyzing {
+                Button("Save Items") { saveItemsAndFinish() }
+                    .disabled(!analysisService.suggestedItems.contains(where: \.isSelected))
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func createBin() {
+        let bin = Bin(
+            name: name.trimmingCharacters(in: .whitespaces),
+            binDescription: binDescription,
+            location: location
+        )
         bin.zone = selectedZone
+
+        // Generate and store QR code
+        if let qrImage = QRGeneratorService.generateQRCode(from: bin.id.uuidString),
+           let qrPath = ImageStorageService.saveImage(qrImage) {
+            bin.qrCodeImagePath = qrPath
+        }
+
         modelContext.insert(bin)
+        createdBin = bin
+        step = .qrAndPhoto
+    }
+
+    private func analyzePhoto() {
+        guard let photo = contentPhoto else { return }
+
+        // Save the content photo to the bin
+        if let bin = createdBin, let path = ImageStorageService.saveImage(photo) {
+            bin.contentImagePaths.append(path)
+        }
+
+        step = .aiResults
+        hasAnalyzed = true
+
+        Task {
+            await analysisService.analyzeImage(photo)
+        }
+    }
+
+    private func saveItemsAndFinish() {
+        guard let bin = createdBin else {
+            dismiss()
+            return
+        }
+
+        let contentImagePath = bin.contentImagePaths.first
+
+        for suggestion in analysisService.suggestedItems where suggestion.isSelected {
+            let item = Item(
+                name: suggestion.name,
+                itemDescription: suggestion.description,
+                bin: bin
+            )
+            item.tags = suggestion.tags
+            if let path = contentImagePath {
+                item.imagePaths = [path]
+            }
+            modelContext.insert(item)
+        }
+
         dismiss()
+    }
+}
+
+private struct SuggestedItemRow: View {
+    @Binding var suggestion: SuggestedItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Toggle("", isOn: $suggestion.isSelected)
+                .labelsHidden()
+
+            VStack(alignment: .leading, spacing: 6) {
+                TextField("Name", text: $suggestion.name)
+                    .font(.headline)
+                TextField("Description", text: $suggestion.description, axis: .vertical)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2...4)
+                if !suggestion.tags.isEmpty {
+                    Text(suggestion.tags.joined(separator: ", "))
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+        .opacity(suggestion.isSelected ? 1 : 0.5)
+        .padding(.vertical, 4)
     }
 }

--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -8,6 +8,7 @@ struct BinDetailView: View {
     @State private var showingAddItem = false
     @State private var showingAIAnalysis = false
     @State private var showingQRCode = false
+    @State private var showingContentCamera = false
     @State private var itemFilter: ItemFilter = .all
 
     enum ItemFilter: String, CaseIterable {
@@ -28,6 +29,26 @@ struct BinDetailView: View {
         List {
             Section {
                 binInfoSection
+            }
+
+            if !bin.contentImagePaths.isEmpty {
+                Section("Bin Photos") {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12) {
+                            ForEach(bin.contentImagePaths, id: \.self) { path in
+                                if let image = ImageStorageService.loadImage(filename: path) {
+                                    Image(uiImage: image)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 150, height: 150)
+                                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                                }
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                    .listRowInsets(EdgeInsets())
+                }
             }
 
             Section {
@@ -79,8 +100,15 @@ struct BinDetailView: View {
                 }
             }
             ToolbarItem(placement: .secondaryAction) {
-                Button(action: { showingQRCode = true }) {
-                    Label("Show QR Code", systemImage: "qrcode")
+                Menu {
+                    Button(action: { showingQRCode = true }) {
+                        Label("Show QR Code", systemImage: "qrcode")
+                    }
+                    Button(action: { showingContentCamera = true }) {
+                        Label("Add Bin Photo", systemImage: "camera")
+                    }
+                } label: {
+                    Label("More", systemImage: "ellipsis.circle")
                 }
             }
         }
@@ -92,6 +120,16 @@ struct BinDetailView: View {
         }
         .sheet(isPresented: $showingQRCode) {
             QRCodeSheet(bin: bin)
+        }
+        .sheet(isPresented: $showingContentCamera) {
+            ImagePickerView(selectedImage: .init(
+                get: { nil },
+                set: { newImage in
+                    if let image = newImage, let path = ImageStorageService.saveImage(image) {
+                        bin.contentImagePaths.append(path)
+                    }
+                }
+            ), sourceType: .camera)
         }
     }
 
@@ -176,7 +214,15 @@ private struct QRCodeSheet: View {
                 Text(bin.name)
                     .font(.title2.weight(.semibold))
 
-                if let qrImage = QRGeneratorService.generateQRCode(from: bin.id.uuidString) {
+                if let qrPath = bin.qrCodeImagePath,
+                   let qrImage = ImageStorageService.loadImage(filename: qrPath) {
+                    Image(uiImage: qrImage)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 250, height: 250)
+                        .padding()
+                } else if let qrImage = QRGeneratorService.generateQRCode(from: bin.id.uuidString) {
                     Image(uiImage: qrImage)
                         .interpolation(.none)
                         .resizable()

--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -208,41 +208,46 @@ private struct QRCodeSheet: View {
     let bin: Bin
     @Environment(\.dismiss) private var dismiss
 
+    private var qrImage: UIImage? {
+        if let qrPath = bin.qrCodeImagePath,
+           let stored = ImageStorageService.loadImage(filename: qrPath) {
+            return stored
+        }
+        return QRGeneratorService.generateQRCode(from: bin.id.uuidString)
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
                 Text(bin.name)
                     .font(.title2.weight(.semibold))
 
-                if let qrPath = bin.qrCodeImagePath,
-                   let qrImage = ImageStorageService.loadImage(filename: qrPath) {
+                if let qrImage {
                     Image(uiImage: qrImage)
                         .interpolation(.none)
                         .resizable()
                         .scaledToFit()
                         .frame(width: 250, height: 250)
-                        .padding()
-                } else if let qrImage = QRGeneratorService.generateQRCode(from: bin.id.uuidString) {
-                    Image(uiImage: qrImage)
-                        .interpolation(.none)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 250, height: 250)
-                        .padding()
+
+                    HStack(spacing: 16) {
+                        ShareLink(
+                            item: Image(uiImage: qrImage),
+                            preview: SharePreview("QR Code: \(bin.name)", image: Image(uiImage: qrImage))
+                        ) {
+                            Label("Share", systemImage: "square.and.arrow.up")
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button(action: { printQRCode(qrImage) }) {
+                            Label("Print", systemImage: "printer")
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                 } else {
                     ContentUnavailableView(
                         "QR Generation Failed",
                         systemImage: "exclamationmark.triangle"
                     )
-                }
-
-                Text(bin.id.uuidString)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-
-                ShareLink(item: bin.id.uuidString, subject: Text("Bin: \(bin.name)")) {
-                    Label("Share QR Data", systemImage: "square.and.arrow.up")
                 }
             }
             .padding()
@@ -253,5 +258,16 @@ private struct QRCodeSheet: View {
                 }
             }
         }
+    }
+
+    private func printQRCode(_ image: UIImage) {
+        let printInfo = UIPrintInfo(dictionary: nil)
+        printInfo.jobName = "QR Code: \(bin.name)"
+        printInfo.outputType = .photo
+
+        let printer = UIPrintInteractionController.shared
+        printer.printInfo = printInfo
+        printer.printingItem = image
+        printer.present(animated: true)
     }
 }

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -60,6 +60,39 @@ final class ModelTests: XCTestCase {
         XCTAssertTrue(bin.items.isEmpty)
         XCTAssertNil(bin.zone)
         XCTAssertNotNil(bin.id)
+        XCTAssertNil(bin.qrCodeImagePath)
+        XCTAssertTrue(bin.contentImagePaths.isEmpty)
+    }
+
+    func test_binQRCodeStorage() throws {
+        let bin = Bin(name: "QR Test Bin")
+        context.insert(bin)
+
+        guard let qrImage = QRGeneratorService.generateQRCode(from: bin.id.uuidString),
+              let qrPath = ImageStorageService.saveImage(qrImage) else {
+            XCTFail("Failed to generate/save QR code")
+            return
+        }
+
+        bin.qrCodeImagePath = qrPath
+        try context.save()
+
+        XCTAssertNotNil(bin.qrCodeImagePath)
+        XCTAssertNotNil(ImageStorageService.loadImage(filename: qrPath))
+
+        // Cleanup
+        ImageStorageService.deleteImage(filename: qrPath)
+    }
+
+    func test_binContentImagePaths() throws {
+        let bin = Bin(name: "Photo Bin")
+        context.insert(bin)
+
+        bin.contentImagePaths = ["photo1.jpg", "photo2.jpg"]
+        try context.save()
+
+        XCTAssertEqual(bin.contentImagePaths.count, 2)
+        XCTAssertTrue(bin.contentImagePaths.contains("photo1.jpg"))
     }
 
     func test_binDelete_cascadesItems() throws {


### PR DESCRIPTION
## Summary

- **Bin model**: added `qrCodeImagePath` and `contentImagePaths` fields so each bin stores its auto-generated QR code and photos of its physical contents
- **Redesigned AddBinView** as a 3-step creation flow: Details → QR + Photo → AI Analysis. QR code is auto-generated and stored on creation. Users can photograph bin contents and optionally run AI to identify and pre-fill items.
- **Updated BinDetailView** to display bin content photos, load stored QR codes, and add bin photos from the detail screen
- **Tests** for new model fields (QR storage, content image paths)

## Test plan

- [ ] Create a new bin — verify QR code is generated and displayed at step 2
- [ ] Take a photo of bin contents at step 2, tap "Analyze with AI" — verify items are suggested
- [ ] Edit/deselect suggested items, save — verify items appear in bin detail
- [ ] Skip photo step (tap "Done") — verify bin is created without items
- [ ] Open bin detail — verify content photos display in horizontal scroll
- [ ] Tap "Show QR Code" — verify stored QR loads (not re-generated)
- [ ] Tap "Add Bin Photo" from overflow menu — verify new photo appends
- [ ] Run unit tests — verify new QR and content image tests pass