### PR TITLE
feat: zone overhaul with colors, icons, detail view, and HomeKit import

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,79 @@
+# binthere — Roadmap
+
+## Completed
+
+### Phase 1: Core App Foundation
+- SwiftData models (Bin, Item, Zone, CheckoutRecord)
+- Tab-based navigation (Bins, Scan, Settings)
+- QR code scanning and generation
+- Item CRUD with photos
+- AI-powered item detection from photos (Claude API)
+- Check-in/check-out flow
+- Unit tests, CI/CD, SwiftLint
+
+### Phase 2: Bin Identity Overhaul + Color Coding
+- Auto-generated 4-char bin codes (e.g. D4J6)
+- Color coding for bins and items
+- Redesigned QR labels with large readable code
+- Share and print QR labels
+- Simplified bin creation flow
+
+### Phase 3: Zone Overhaul + Smart Home Import
+- Zone colors and SF Symbol icons
+- Zone detail view with bin listing
+- HomeKit room import (one-time)
+- Group-by-zone in bin list
+- Icon picker with 24 preset symbols
+
+## Up Next
+
+### Phase 4: NFC Support
+- Scan NFC tags to open bins/items (Core NFC)
+- Write bin UUID to NFC tags
+- NFC as alternative to QR for smaller items
+
+### Phase 5: Item Enrichment
+- Custom attributes on items/bins (beyond key-value)
+- Object notes (rich text)
+- Valuations: manual input, AI estimation, or combined
+- Total valuation rollups per bin/zone/overall
+
+### Phase 6: Reports & Printing
+- Print bin manifests (itemized contents list)
+- Insurance reports (items with photos, valuations, locations)
+- Graphical reports (Swift Charts — value by zone, checkout frequency)
+
+### Phase 7: Multi-User & Permissions
+- Invite users to your household
+- Per-bin or per-item permission levels (view, checkout, manage)
+- Checkout auto-populates current user's name
+- Item creators set constraints: who can check out, max duration, availability
+- See who has what checked out and expected return dates
+- Ping household members to return items
+
+### Phase 8: Notifications
+- Items due back reminders (UserNotifications + APNs)
+- "Someone needs this item" push to current holder
+- Checkout/checkin activity feed
+
+### Phase 9: Operations & Polish
+- Bulk select / edit / delete
+- Move entire bins between zones
+- Improved item move UX
+- Search improvements (filters, saved searches)
+
+### Phase 10: Sync & Backend
+- Supabase backend (Auth, PostgreSQL, Storage)
+- Multi-device sync via Supabase
+- Offline-first with conflict resolution
+- Row Level Security for household isolation
+
+## Ideas (Unprioritized)
+- Apple Home / Google Home room live sync
+- Barcode scanning for commercial products
+- Item templates / categories
+- Export data (CSV, JSON)
+- iPad layout optimizations
+- Apple Watch companion (quick scan + checkout)
+- Siri Shortcuts integration
+- Widget for recently checked out items

--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		CC00000100000001AAAAAA01 /* IconPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000001BBBBBB01 /* IconPalette.swift */; };
 		CC00000100000002AAAAAA01 /* ZoneDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000002BBBBBB01 /* ZoneDetailView.swift */; };
 		CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000003BBBBBB01 /* HomeKitService.swift */; };
+		CC00000100000004AAAAAA01 /* ZonesGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000004BBBBBB01 /* ZonesGridView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,6 +93,7 @@
 		CC00000100000001BBBBBB01 /* IconPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPalette.swift; sourceTree = "<group>"; };
 		CC00000100000002BBBBBB01 /* ZoneDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneDetailView.swift; sourceTree = "<group>"; };
 		CC00000100000003BBBBBB01 /* HomeKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeKitService.swift; sourceTree = "<group>"; };
+		CC00000100000004BBBBBB01 /* ZonesGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZonesGridView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,6 +200,7 @@
 				AA00000100000005BBBBBB01 /* MainTabView.swift */,
 				AA00000100000023CCCCCC01 /* Bins */,
 				AA00000100000024CCCCCC01 /* Items */,
+				CC00000100000005CCCCCC01 /* Zones */,
 				AA00000100000025CCCCCC01 /* Scanner */,
 				AA00000100000026CCCCCC01 /* Settings */,
 			);
@@ -251,6 +254,14 @@
 				CC00000100000002BBBBBB01 /* ZoneDetailView.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		CC00000100000005CCCCCC01 /* Zones */ = {
+			isa = PBXGroup;
+			children = (
+				CC00000100000004BBBBBB01 /* ZonesGridView.swift */,
+			);
+			path = Zones;
 			sourceTree = "<group>";
 		};
 		BB00000100000003CCCCCC01 /* Utilities */ = {
@@ -419,6 +430,7 @@
 				CC00000100000001AAAAAA01 /* IconPalette.swift in Sources */,
 				CC00000100000002AAAAAA01 /* ZoneDetailView.swift in Sources */,
 				CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */,
+				CC00000100000004AAAAAA01 /* ZonesGridView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		AA00000100000012AAAAAA01 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBD3E252BEAC2D100B0C02C /* ContentView.swift */; };
 		BB00000100000001AAAAAA01 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000100000001BBBBBB01 /* ColorPalette.swift */; };
 		BB00000100000002AAAAAA01 /* CodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000100000002BBBBBB01 /* CodeGenerator.swift */; };
+		CC00000100000001AAAAAA01 /* IconPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000001BBBBBB01 /* IconPalette.swift */; };
+		CC00000100000002AAAAAA01 /* ZoneDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000002BBBBBB01 /* ZoneDetailView.swift */; };
+		CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000003BBBBBB01 /* HomeKitService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,6 +89,9 @@
 		AA00000100000011BBBBBB01 /* ImageAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAnalysisService.swift; sourceTree = "<group>"; };
 		BB00000100000001BBBBBB01 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		BB00000100000002BBBBBB01 /* CodeGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeGenerator.swift; sourceTree = "<group>"; };
+		CC00000100000001BBBBBB01 /* IconPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPalette.swift; sourceTree = "<group>"; };
+		CC00000100000002BBBBBB01 /* ZoneDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneDetailView.swift; sourceTree = "<group>"; };
+		CC00000100000003BBBBBB01 /* HomeKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeKitService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +210,7 @@
 				AA0000010000000FBBBBBB01 /* ImageStorageService.swift */,
 				AA00000100000010BBBBBB01 /* QRGeneratorService.swift */,
 				AA00000100000011BBBBBB01 /* ImageAnalysisService.swift */,
+				CC00000100000003BBBBBB01 /* HomeKitService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -241,6 +248,7 @@
 			children = (
 				AA0000010000000DBBBBBB01 /* SettingsView.swift */,
 				AA0000010000000EBBBBBB01 /* ZoneManagementView.swift */,
+				CC00000100000002BBBBBB01 /* ZoneDetailView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -250,6 +258,7 @@
 			children = (
 				BB00000100000001BBBBBB01 /* ColorPalette.swift */,
 				BB00000100000002BBBBBB01 /* CodeGenerator.swift */,
+				CC00000100000001BBBBBB01 /* IconPalette.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -407,6 +416,9 @@
 				AA00000100000011AAAAAA01 /* ImageAnalysisService.swift in Sources */,
 				BB00000100000001AAAAAA01 /* ColorPalette.swift in Sources */,
 				BB00000100000002AAAAAA01 /* CodeGenerator.swift in Sources */,
+				CC00000100000001AAAAAA01 /* IconPalette.swift in Sources */,
+				CC00000100000002AAAAAA01 /* ZoneDetailView.swift in Sources */,
+				CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -574,6 +586,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "binthere needs camera access to scan QR codes and take photos of items.";
+				INFOPLIST_KEY_NSHomeKitUsageDescription = "binthere can import room names from HomeKit to use as zones.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -604,6 +617,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "binthere needs camera access to scan QR codes and take photos of items.";
+				INFOPLIST_KEY_NSHomeKitUsageDescription = "binthere can import room names from HomeKit to use as zones.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/binthere/Models/Zone.swift
+++ b/binthere/Models/Zone.swift
@@ -6,13 +6,21 @@ final class Zone {
     var id: UUID = UUID()
     var name: String = ""
     var locationDescription: String = ""
+    var color: String = ""
+    var icon: String = ""
 
     @Relationship(deleteRule: .nullify, inverse: \Bin.zone)
     var bins: [Bin] = []
 
-    init(name: String, locationDescription: String = "") {
+    var totalItemCount: Int {
+        bins.reduce(0) { $0 + $1.items.count }
+    }
+
+    init(name: String, locationDescription: String = "", color: String = "", icon: String = "") {
         self.id = UUID()
         self.name = name
         self.locationDescription = locationDescription
+        self.color = color
+        self.icon = icon
     }
 }

--- a/binthere/Services/HomeKitService.swift
+++ b/binthere/Services/HomeKitService.swift
@@ -1,0 +1,43 @@
+import HomeKit
+
+@Observable
+final class HomeKitService: NSObject, HMHomeManagerDelegate {
+    var rooms: [String] = []
+    var isLoading = false
+    var error: String?
+
+    private var homeManager: HMHomeManager?
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func fetchRooms() async {
+        isLoading = true
+        error = nil
+        rooms = []
+
+        homeManager = HMHomeManager()
+        homeManager?.delegate = self
+
+        // Wait for HomeKit to deliver homes
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+
+        isLoading = false
+    }
+
+    func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
+        let allRooms = manager.homes
+            .flatMap(\.rooms)
+            .map(\.name)
+
+        // Deduplicate and sort
+        rooms = Array(Set(allRooms)).sorted()
+
+        if rooms.isEmpty && manager.homes.isEmpty {
+            error = "No homes configured in HomeKit. Set up a home in the Home app first."
+        }
+
+        continuation?.resume()
+        continuation = nil
+    }
+}

--- a/binthere/Utilities/IconPalette.swift
+++ b/binthere/Utilities/IconPalette.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+enum IconPalette {
+    struct IconGroup: Identifiable {
+        let id: String
+        let name: String
+        let icons: [String]
+    }
+
+    static let groups: [IconGroup] = [
+        IconGroup(id: "general", name: "General", icons: [
+            "house", "building.2", "shippingbox", "map",
+        ]),
+        IconGroup(id: "living", name: "Living", icons: [
+            "sofa", "tv", "bed.double", "chair.lounge",
+        ]),
+        IconGroup(id: "work", name: "Work", icons: [
+            "desktopcomputer", "wrench", "hammer", "paintbrush",
+        ]),
+        IconGroup(id: "storage", name: "Storage", icons: [
+            "archivebox", "tray.2", "cabinet", "cube.box",
+        ]),
+        IconGroup(id: "outdoor", name: "Outdoor", icons: [
+            "leaf", "car", "bicycle", "tree",
+        ]),
+        IconGroup(id: "kitchen", name: "Kitchen & Bath", icons: [
+            "fork.knife", "cup.and.saucer", "drop", "washer",
+        ]),
+    ]
+
+    static let allIcons: [String] = groups.flatMap(\.icons)
+
+    static let defaultIcon = "archivebox"
+}
+
+struct IconPickerGrid: View {
+    @Binding var selectedIcon: String
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 6)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(IconPalette.groups) { group in
+                Text(group.name)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(group.icons, id: \.self) { icon in
+                        Image(systemName: icon)
+                            .font(.title3)
+                            .frame(width: 40, height: 40)
+                            .background(
+                                selectedIcon == icon
+                                    ? Color.accentColor.opacity(0.15)
+                                    : Color.clear
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .strokeBorder(
+                                        selectedIcon == icon ? Color.accentColor : Color.clear,
+                                        lineWidth: 2
+                                    )
+                            )
+                            .onTapGesture {
+                                selectedIcon = selectedIcon == icon ? "" : icon
+                            }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ZoneIcon: View {
+    let iconName: String
+    let colorName: String
+    var size: CGFloat = 20
+
+    var body: some View {
+        Image(systemName: iconName.isEmpty ? IconPalette.defaultIcon : iconName)
+            .font(.system(size: size * 0.7))
+            .foregroundStyle(colorName.isEmpty ? .secondary : ColorPalette.from(colorName).color)
+            .frame(width: size, height: size)
+    }
+}

--- a/binthere/Utilities/IconPalette.swift
+++ b/binthere/Utilities/IconPalette.swift
@@ -39,11 +39,12 @@ struct IconPickerGrid: View {
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 6)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(spacing: 12) {
             ForEach(IconPalette.groups) { group in
                 Text(group.name)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
 
                 LazyVGrid(columns: columns, spacing: 12) {
                     ForEach(group.icons, id: \.self) { icon in

--- a/binthere/Views/Bins/AddBinView.swift
+++ b/binthere/Views/Bins/AddBinView.swift
@@ -74,7 +74,12 @@ struct AddBinView: View {
                 Picker("Zone", selection: $selectedZone) {
                     Text("None").tag(nil as Zone?)
                     ForEach(zones) { zone in
-                        Text(zone.name).tag(zone as Zone?)
+                        Label {
+                            Text(zone.name)
+                        } icon: {
+                            ZoneIcon(iconName: zone.icon, colorName: zone.color)
+                        }
+                        .tag(zone as Zone?)
                     }
                 }
                 TextField("Location (optional)", text: $location)

--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -152,8 +152,12 @@ struct BinDetailView: View {
             }
             HStack(spacing: 16) {
                 if let zone = bin.zone {
-                    Label(zone.name, systemImage: "mappin")
-                        .font(.caption)
+                    Label {
+                        Text(zone.name)
+                    } icon: {
+                        ZoneIcon(iconName: zone.icon, colorName: zone.color, size: 14)
+                    }
+                    .font(.caption)
                 }
                 if !bin.location.isEmpty {
                     Label(bin.location, systemImage: "location")

--- a/binthere/Views/Bins/BinListView.swift
+++ b/binthere/Views/Bins/BinListView.swift
@@ -6,6 +6,7 @@ struct BinListView: View {
     @Query(sort: \Bin.code) private var bins: [Bin]
     @State private var searchText = ""
     @State private var showingAddBin = false
+    @State private var groupByZone = false
 
     private var filteredBins: [Bin] {
         if searchText.isEmpty { return bins }
@@ -18,6 +19,29 @@ struct BinListView: View {
         }
     }
 
+    private var groupedBins: [(zone: Zone?, bins: [Bin])] {
+        let dict = Dictionary(grouping: filteredBins) { $0.zone }
+        var result: [(zone: Zone?, bins: [Bin])] = []
+
+        // Named zones first, sorted alphabetically
+        let namedZones = dict.keys
+            .compactMap { $0 }
+            .sorted { $0.name < $1.name }
+
+        for zone in namedZones {
+            if let zoneBins = dict[zone] {
+                result.append((zone: zone, bins: zoneBins.sorted { $0.code < $1.code }))
+            }
+        }
+
+        // Unzoned bins last
+        if let unzoned = dict[nil] {
+            result.append((zone: nil, bins: unzoned.sorted { $0.code < $1.code }))
+        }
+
+        return result
+    }
+
     var body: some View {
         List {
             if filteredBins.isEmpty {
@@ -26,6 +50,31 @@ struct BinListView: View {
                     systemImage: searchText.isEmpty ? "archivebox" : "magnifyingglass",
                     description: Text(searchText.isEmpty ? "Tap + to create your first bin." : "No bins match your search.")
                 )
+            } else if groupByZone {
+                ForEach(groupedBins, id: \.zone?.id) { group in
+                    Section {
+                        ForEach(group.bins) { bin in
+                            NavigationLink(value: bin) {
+                                BinRowView(bin: bin)
+                            }
+                        }
+                        .onDelete { offsets in
+                            for index in offsets {
+                                modelContext.delete(group.bins[index])
+                            }
+                        }
+                    } header: {
+                        if let zone = group.zone {
+                            Label {
+                                Text(zone.name)
+                            } icon: {
+                                ZoneIcon(iconName: zone.icon, colorName: zone.color, size: 16)
+                            }
+                        } else {
+                            Text("No Zone")
+                        }
+                    }
+                }
             } else {
                 ForEach(filteredBins) { bin in
                     NavigationLink(value: bin) {
@@ -41,8 +90,16 @@ struct BinListView: View {
         }
         .searchable(text: $searchText, prompt: "Search by code, label, or items")
         .toolbar {
-            Button(action: { showingAddBin = true }) {
-                Label("Add Bin", systemImage: "plus")
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button(action: { groupByZone.toggle() }) {
+                    Label(
+                        groupByZone ? "Flat List" : "Group by Zone",
+                        systemImage: groupByZone ? "list.bullet" : "rectangle.3.group"
+                    )
+                }
+                Button(action: { showingAddBin = true }) {
+                    Label("Add Bin", systemImage: "plus")
+                }
             }
         }
         .sheet(isPresented: $showingAddBin) {
@@ -76,9 +133,13 @@ private struct BinRowView: View {
                 }
                 HStack(spacing: 12) {
                     if let zone = bin.zone {
-                        Label(zone.name, systemImage: "mappin")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        Label {
+                            Text(zone.name)
+                        } icon: {
+                            ZoneIcon(iconName: zone.icon, colorName: zone.color, size: 12)
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                     if !bin.location.isEmpty {
                         Label(bin.location, systemImage: "location")

--- a/binthere/Views/MainTabView.swift
+++ b/binthere/Views/MainTabView.swift
@@ -11,6 +11,13 @@ struct MainTabView: View {
             }
 
             NavigationStack {
+                ZonesGridView()
+            }
+            .tabItem {
+                Label("Zones", systemImage: "square.grid.2x2")
+            }
+
+            NavigationStack {
                 ScannerTab()
             }
             .tabItem {

--- a/binthere/Views/Settings/SettingsView.swift
+++ b/binthere/Views/Settings/SettingsView.swift
@@ -6,12 +6,6 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section("Zones") {
-                NavigationLink("Manage Zones") {
-                    ZoneManagementView()
-                }
-            }
-
             Section("AI Analysis") {
                 HStack {
                     if showingAPIKey {

--- a/binthere/Views/Settings/ZoneDetailView.swift
+++ b/binthere/Views/Settings/ZoneDetailView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import SwiftData
+
+struct ZoneDetailView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var zone: Zone
+
+    @State private var showingDeleteConfirmation = false
+
+    var body: some View {
+        List {
+            Section {
+                headerSection
+            }
+
+            Section("Details") {
+                LabeledContent("Name") {
+                    TextField("Name", text: $zone.name)
+                        .multilineTextAlignment(.trailing)
+                }
+                LabeledContent("Description") {
+                    TextField("Description", text: $zone.locationDescription, axis: .vertical)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+
+            Section("Color") {
+                ColorPickerRow(selectedColor: $zone.color)
+            }
+
+            Section("Icon") {
+                IconPickerGrid(selectedIcon: $zone.icon)
+            }
+
+            Section("Bins (\(zone.bins.count))") {
+                if zone.bins.isEmpty {
+                    ContentUnavailableView(
+                        "No Bins",
+                        systemImage: "archivebox",
+                        description: Text("No bins are assigned to this zone yet.")
+                    )
+                } else {
+                    ForEach(zone.bins.sorted(by: { $0.code < $1.code })) { bin in
+                        NavigationLink(value: bin) {
+                            HStack(spacing: 12) {
+                                ColorDot(colorName: bin.color, size: 14)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(bin.code)
+                                        .font(.headline.monospaced())
+                                    if !bin.name.isEmpty {
+                                        Text(bin.name)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                                Spacer()
+                                Text("\(bin.items.count) items")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section {
+                Button(role: .destructive, action: { showingDeleteConfirmation = true }) {
+                    Label("Delete Zone", systemImage: "trash")
+                }
+            }
+        }
+        .navigationTitle(zone.name)
+        .navigationDestination(for: Bin.self) { bin in
+            BinDetailView(bin: bin)
+        }
+        .alert("Delete Zone?", isPresented: $showingDeleteConfirmation) {
+            Button("Delete", role: .destructive) {
+                modelContext.delete(zone)
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Bins in this zone will keep their data but lose their zone assignment.")
+        }
+    }
+
+    private var headerSection: some View {
+        HStack(spacing: 16) {
+            ZoneIcon(iconName: zone.icon, colorName: zone.color, size: 44)
+                .frame(width: 50, height: 50)
+                .background(ColorPalette.from(zone.color).color.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(zone.name)
+                    .font(.title3.weight(.semibold))
+                HStack(spacing: 12) {
+                    Label("\(zone.bins.count) bins", systemImage: "archivebox")
+                    Label("\(zone.totalItemCount) items", systemImage: "cube.box")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/binthere/Views/Settings/ZoneManagementView.swift
+++ b/binthere/Views/Settings/ZoneManagementView.swift
@@ -143,7 +143,7 @@ struct AddZoneSheet: View {
     }
 }
 
-private struct HomeKitImportSheet: View {
+struct HomeKitImportSheet: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @Query(sort: \Zone.name) private var existingZones: [Zone]

--- a/binthere/Views/Settings/ZoneManagementView.swift
+++ b/binthere/Views/Settings/ZoneManagementView.swift
@@ -5,8 +5,7 @@ struct ZoneManagementView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Zone.name) private var zones: [Zone]
     @State private var showingAddZone = false
-    @State private var newZoneName = ""
-    @State private var newZoneDescription = ""
+    @State private var showingHomeKitImport = false
 
     var body: some View {
         List {
@@ -18,54 +17,217 @@ struct ZoneManagementView: View {
                 )
             } else {
                 ForEach(zones) { zone in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(zone.name)
-                            .font(.headline)
-                        if !zone.locationDescription.isEmpty {
-                            Text(zone.locationDescription)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        Text("\(zone.bins.count) bins")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    NavigationLink(value: zone) {
+                        ZoneRowView(zone: zone)
                     }
-                    .padding(.vertical, 2)
                 }
                 .onDelete(perform: deleteZones)
             }
         }
         .navigationTitle("Zones")
+        .navigationDestination(for: Zone.self) { zone in
+            ZoneDetailView(zone: zone)
+        }
         .toolbar {
-            Button(action: { showingAddZone = true }) {
-                Label("Add Zone", systemImage: "plus")
+            ToolbarItemGroup(placement: .primaryAction) {
+                Menu {
+                    Button(action: { showingAddZone = true }) {
+                        Label("New Zone", systemImage: "plus")
+                    }
+                    Button(action: { showingHomeKitImport = true }) {
+                        Label("Import from Home", systemImage: "house")
+                    }
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
             }
         }
-        .alert("New Zone", isPresented: $showingAddZone) {
-            TextField("Zone Name", text: $newZoneName)
-            TextField("Description (optional)", text: $newZoneDescription)
-            Button("Add") { addZone() }
-            Button("Cancel", role: .cancel) {
-                newZoneName = ""
-                newZoneDescription = ""
-            }
+        .sheet(isPresented: $showingAddZone) {
+            AddZoneSheet()
         }
-    }
-
-    private func addZone() {
-        guard !newZoneName.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-        let zone = Zone(
-            name: newZoneName.trimmingCharacters(in: .whitespaces),
-            locationDescription: newZoneDescription
-        )
-        modelContext.insert(zone)
-        newZoneName = ""
-        newZoneDescription = ""
+        .sheet(isPresented: $showingHomeKitImport) {
+            HomeKitImportSheet()
+        }
     }
 
     private func deleteZones(at offsets: IndexSet) {
         for index in offsets {
             modelContext.delete(zones[index])
         }
+    }
+}
+
+private struct ZoneRowView: View {
+    let zone: Zone
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZoneIcon(iconName: zone.icon, colorName: zone.color, size: 32)
+                .frame(width: 40, height: 40)
+                .background(ColorPalette.from(zone.color).color.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(zone.name)
+                    .font(.headline)
+                if !zone.locationDescription.isEmpty {
+                    Text(zone.locationDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Text("\(zone.bins.count) bins")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct AddZoneSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var locationDescription = ""
+    @State private var selectedColor = ""
+    @State private var selectedIcon = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("Zone Name", text: $name)
+                }
+
+                Section("Description") {
+                    TextField("Description (optional)", text: $locationDescription, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+
+                Section("Color") {
+                    ColorPickerRow(selectedColor: $selectedColor)
+                }
+
+                Section("Icon") {
+                    IconPickerGrid(selectedIcon: $selectedIcon)
+                }
+            }
+            .navigationTitle("New Zone")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") { addZone() }
+                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func addZone() {
+        let zone = Zone(
+            name: name.trimmingCharacters(in: .whitespaces),
+            locationDescription: locationDescription,
+            color: selectedColor,
+            icon: selectedIcon
+        )
+        modelContext.insert(zone)
+        dismiss()
+    }
+}
+
+private struct HomeKitImportSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \Zone.name) private var existingZones: [Zone]
+
+    @State private var homeKitService = HomeKitService()
+    @State private var selectedRooms = Set<String>()
+
+    private var availableRooms: [String] {
+        let existingNames = Set(existingZones.map(\.name.lowercased()))
+        return homeKitService.rooms.filter { !existingNames.contains($0.lowercased()) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if homeKitService.isLoading {
+                    VStack(spacing: 16) {
+                        ProgressView()
+                        Text("Reading rooms from HomeKit...")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let error = homeKitService.error {
+                    ContentUnavailableView(
+                        "Can't Access Home",
+                        systemImage: "house.slash",
+                        description: Text(error)
+                    )
+                } else if availableRooms.isEmpty {
+                    ContentUnavailableView(
+                        "No New Rooms",
+                        systemImage: "checkmark.circle",
+                        description: Text(
+                            homeKitService.rooms.isEmpty
+                                ? "No rooms found in HomeKit. Set up rooms in the Home app first."
+                                : "All HomeKit rooms are already zones."
+                        )
+                    )
+                } else {
+                    List(availableRooms, id: \.self) { room in
+                        HStack {
+                            Text(room)
+                            Spacer()
+                            if selectedRooms.contains(room) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.blue)
+                            } else {
+                                Image(systemName: "circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            if selectedRooms.contains(room) {
+                                selectedRooms.remove(room)
+                            } else {
+                                selectedRooms.insert(room)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Import Rooms")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Import (\(selectedRooms.count))") { importRooms() }
+                        .disabled(selectedRooms.isEmpty)
+                }
+            }
+            .task {
+                await homeKitService.fetchRooms()
+            }
+        }
+    }
+
+    private func importRooms() {
+        for roomName in selectedRooms {
+            let zone = Zone(name: roomName, icon: "house")
+            modelContext.insert(zone)
+        }
+        dismiss()
     }
 }

--- a/binthere/Views/Zones/ZonesGridView.swift
+++ b/binthere/Views/Zones/ZonesGridView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import SwiftData
+
+struct ZonesGridView: View {
+    @Query(sort: \Zone.name) private var zones: [Zone]
+    @State private var showingAddZone = false
+    @State private var showingHomeKitImport = false
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 16),
+        GridItem(.flexible(), spacing: 16),
+    ]
+
+    var body: some View {
+        ScrollView {
+            if zones.isEmpty {
+                ContentUnavailableView(
+                    "No Zones",
+                    systemImage: "square.grid.2x2",
+                    description: Text("Zones represent rooms or areas. Tap + to create one.")
+                )
+                .padding(.top, 60)
+            } else {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(zones) { zone in
+                        NavigationLink(value: zone) {
+                            ZoneCard(zone: zone)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("Zones")
+        .navigationDestination(for: Zone.self) { zone in
+            ZoneDetailView(zone: zone)
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Menu {
+                    Button(action: { showingAddZone = true }) {
+                        Label("New Zone", systemImage: "plus")
+                    }
+                    Button(action: { showingHomeKitImport = true }) {
+                        Label("Import from Home", systemImage: "house")
+                    }
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingAddZone) {
+            AddZoneSheet()
+        }
+        .sheet(isPresented: $showingHomeKitImport) {
+            HomeKitImportSheet()
+        }
+    }
+}
+
+private struct ZoneCard: View {
+    let zone: Zone
+
+    private var zoneColor: Color {
+        zone.color.isEmpty ? .gray : ColorPalette.from(zone.color).color
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                ZoneIcon(iconName: zone.icon, colorName: zone.color, size: 28)
+                    .frame(width: 36, height: 36)
+                    .background(.white.opacity(0.25))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                Spacer()
+
+                Text("\(zone.bins.count)")
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.white)
+            }
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(zone.name)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+
+                HStack(spacing: 12) {
+                    Label("\(zone.bins.count) bins", systemImage: "archivebox")
+                    Label("\(zone.totalItemCount) items", systemImage: "cube.box")
+                }
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.8))
+            }
+
+            if !zone.locationDescription.isEmpty {
+                Text(zone.locationDescription)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .lineLimit(1)
+            }
+        }
+        .padding()
+        .frame(minHeight: 140)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(zoneColor.gradient)
+        )
+        .shadow(color: zoneColor.opacity(0.3), radius: 6, y: 3)
+    }
+}

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -30,6 +30,38 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(zone.name, "Garage")
         XCTAssertEqual(zone.locationDescription, "Detached garage")
         XCTAssertTrue(zone.bins.isEmpty)
+        XCTAssertTrue(zone.color.isEmpty)
+        XCTAssertTrue(zone.icon.isEmpty)
+    }
+
+    func test_zoneCreation_withColorAndIcon() throws {
+        let zone = Zone(name: "Office", color: "blue", icon: "desktopcomputer")
+        context.insert(zone)
+        try context.save()
+
+        XCTAssertEqual(zone.color, "blue")
+        XCTAssertEqual(zone.icon, "desktopcomputer")
+    }
+
+    func test_zoneTotalItemCount() throws {
+        let zone = Zone(name: "Garage")
+        let bin1 = Bin(code: "G001")
+        let bin2 = Bin(code: "G002")
+        bin1.zone = zone
+        bin2.zone = zone
+        let item1 = Item(name: "Hammer", bin: bin1)
+        let item2 = Item(name: "Wrench", bin: bin1)
+        let item3 = Item(name: "Drill", bin: bin2)
+        context.insert(zone)
+        context.insert(bin1)
+        context.insert(bin2)
+        context.insert(item1)
+        context.insert(item2)
+        context.insert(item3)
+        try context.save()
+
+        XCTAssertEqual(zone.totalItemCount, 3)
+        XCTAssertEqual(zone.bins.count, 2)
     }
 
     func test_zoneDelete_nullifiesBinZone() throws {


### PR DESCRIPTION
## Summary

- **Zone model**: added `color` and `icon` fields, `totalItemCount` computed property
- **ZoneDetailView**: full detail screen with icon/color header, inline editing, list of bins in zone with navigation, delete with confirmation
- **ZoneManagementView overhaul**: rows show icon + color + bin count, NavigationLink to detail, proper add zone sheet with color picker and icon picker
- **HomeKit room import**: one-time import of room names from Apple Home app as zones (reads via HMHomeManager, no live sync)
- **IconPalette**: 24 SF Symbols organized by room type, reusable IconPickerGrid and ZoneIcon components
- **BinListView**: group-by-zone toggle (sections with zone icon headers), zone icons in bin rows
- **Zone pickers**: all zone pickers now show icon + color for visual identification

## Test plan

- [ ] Create a zone with color + icon → verify it shows in zone list with visual identity
- [ ] Tap zone → verify detail view shows bins, counts, edit controls
- [ ] Edit zone color/icon → verify updates in zone list and bin views
- [ ] Group bins by zone in BinListView → verify sections with zone headers
- [ ] Create bin with zone → verify zone icon appears in bin row and detail
- [ ] Import from HomeKit → verify rooms appear as zones (device only)
- [ ] Delete zone → verify bins lose zone but keep data
- [ ] Run unit tests