### PR TITLE
refactor: prioritize bins and collapse zone settings in detail view

### DIFF
--- a/binthere/Views/Settings/ZoneDetailView.swift
+++ b/binthere/Views/Settings/ZoneDetailView.swift
@@ -15,31 +15,12 @@ struct ZoneDetailView: View {
                 headerSection
             }
 
-            Section("Details") {
-                LabeledContent("Name") {
-                    TextField("Name", text: $zone.name)
-                        .multilineTextAlignment(.trailing)
-                }
-                LabeledContent("Description") {
-                    TextField("Description", text: $zone.locationDescription, axis: .vertical)
-                        .multilineTextAlignment(.trailing)
-                }
-            }
-
-            Section("Color") {
-                ColorPickerRow(selectedColor: $zone.color)
-            }
-
-            Section("Icon") {
-                IconPickerGrid(selectedIcon: $zone.icon)
-            }
-
             Section("Bins (\(zone.bins.count))") {
                 if zone.bins.isEmpty {
                     ContentUnavailableView(
                         "No Bins",
                         systemImage: "archivebox",
-                        description: Text("No bins are assigned to this zone yet.")
+                        description: Text("Tap + to add a bin to this zone.")
                     )
                 } else {
                     ForEach(zone.bins.sorted(by: { $0.code < $1.code })) { bin in
@@ -62,6 +43,33 @@ struct ZoneDetailView: View {
                             }
                         }
                     }
+                }
+            }
+
+            Section {
+                DisclosureGroup("Zone Settings") {
+                    LabeledContent("Name") {
+                        TextField("Name", text: $zone.name)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Description") {
+                        TextField("Description", text: $zone.locationDescription, axis: .vertical)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Color")
+                            .font(.subheadline)
+                        ColorPickerRow(selectedColor: $zone.color)
+                    }
+                    .padding(.vertical, 4)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Icon")
+                            .font(.subheadline)
+                        IconPickerGrid(selectedIcon: $zone.icon)
+                    }
+                    .padding(.vertical, 4)
                 }
             }
 


### PR DESCRIPTION
Bins are the primary content of a zone, so they now appear directly below the header. Name, description, color, and icon are tucked into a collapsible "Zone Settings" disclosure group below the bins so they don't dominate the layout with a giant icon picker.