### PR TITLE
feat: item enrichment — notes, custom attributes, valuations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,12 @@ jobs:
             -destination "platform=iOS Simulator,name=${{ steps.dest.outputs.simulator }}" \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO
-      - name: Run Tests
+      - name: Run Unit Tests
         run: |
           xcodebuild test \
             -scheme binthere \
             -destination "platform=iOS Simulator,name=${{ steps.dest.outputs.simulator }}" \
+            -only-testing:binthereTests \
             -skipPackagePluginValidation \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Select latest Xcode
         run: |
-          # Find the latest Xcode version installed on the runner
           LATEST_XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
           if [ -z "$LATEST_XCODE" ]; then
             LATEST_XCODE="/Applications/Xcode.app"
@@ -39,8 +38,6 @@ jobs:
       - name: Resolve destination
         id: dest
         run: |
-          # Pick the first available iPhone simulator matching the active Xcode
-          xcrun simctl list devices available
           DEST=$(xcrun simctl list devices available -j \
             | python3 -c "
           import json, sys
@@ -55,6 +52,22 @@ jobs:
           ")
           echo "simulator=$DEST" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEST"
+      - name: Boot simulator
+        run: |
+          UDID=$(xcrun simctl list devices available -j \
+            | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          for runtime, devices in sorted(data['devices'].items()):
+              if 'iOS' in runtime:
+                  for d in devices:
+                      if d['name'] == '${{ steps.dest.outputs.simulator }}' and d['isAvailable']:
+                          print(d['udid'])
+                          sys.exit(0)
+          ")
+          xcrun simctl boot "$UDID" || true
+          # Wait for the simulator to finish booting
+          xcrun simctl bootstatus "$UDID" -b
       - name: Build
         run: |
           xcodebuild build \
@@ -69,11 +82,34 @@ jobs:
             -destination "platform=iOS Simulator,name=${{ steps.dest.outputs.simulator }}" \
             -only-testing:binthereTests \
             -skipPackagePluginValidation \
-            -resultBundlePath TestResults.xcresult \
+            -resultBundlePath UnitTestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO
+      - name: Run UI Tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "UI test attempt $attempt..."
+            if xcodebuild test \
+              -scheme binthere \
+              -destination "platform=iOS Simulator,name=${{ steps.dest.outputs.simulator }}" \
+              -only-testing:binthereUITests \
+              -skipPackagePluginValidation \
+              -resultBundlePath "UITestResults-$attempt.xcresult" \
+              CODE_SIGNING_ALLOWED=NO; then
+              echo "UI tests passed on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "UI tests failed after 3 attempts"
+              exit 1
+            fi
+            echo "Retrying..."
+            sleep 5
+          done
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results
-          path: TestResults.xcresult
+          path: |
+            UnitTestResults.xcresult
+            UITestResults-*.xcresult

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,7 +48,7 @@ type_body_length:
   error: 500
 
 file_length:
-  warning: 500
+  warning: 700
   error: 1000
 
 function_body_length:

--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000003BBBBBB01 /* HomeKitService.swift */; };
 		CC00000100000004AAAAAA01 /* ZonesGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000004BBBBBB01 /* ZonesGridView.swift */; };
 		DD00000100000001AAAAAA01 /* NFCService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00000100000001BBBBBB01 /* NFCService.swift */; };
+		EE00000100000001AAAAAA01 /* CustomAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000001BBBBBB01 /* CustomAttribute.swift */; };
+		EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */; };
+		EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000003BBBBBB01 /* SetValueSheet.swift */; };
+		EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +100,10 @@
 		CC00000100000003BBBBBB01 /* HomeKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeKitService.swift; sourceTree = "<group>"; };
 		CC00000100000004BBBBBB01 /* ZonesGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZonesGridView.swift; sourceTree = "<group>"; };
 		DD00000100000001BBBBBB01 /* NFCService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCService.swift; sourceTree = "<group>"; };
+		EE00000100000001BBBBBB01 /* CustomAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAttribute.swift; sourceTree = "<group>"; };
+		EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
+		EE00000100000003BBBBBB01 /* SetValueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetValueSheet.swift; sourceTree = "<group>"; };
+		EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributeSheet.swift; sourceTree = "<group>"; };
 		DD00000100000002BBBBBB01 /* binthere.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = binthere.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -194,6 +202,7 @@
 				AA00000100000002BBBBBB01 /* Zone.swift */,
 				AA00000100000003BBBBBB01 /* Bin.swift */,
 				AA00000100000004BBBBBB01 /* CheckoutRecord.swift */,
+				EE00000100000001BBBBBB01 /* CustomAttribute.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -239,6 +248,8 @@
 				AA00000100000009BBBBBB01 /* AddItemView.swift */,
 				AA0000010000000ABBBBBB01 /* ItemDetailView.swift */,
 				AA0000010000000BBBBBBB01 /* AIAnalysisView.swift */,
+				EE00000100000003BBBBBB01 /* SetValueSheet.swift */,
+				EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */,
 			);
 			path = Items;
 			sourceTree = "<group>";
@@ -267,6 +278,7 @@
 				BB00000100000001BBBBBB01 /* ColorPalette.swift */,
 				BB00000100000002BBBBBB01 /* CodeGenerator.swift */,
 				CC00000100000001BBBBBB01 /* IconPalette.swift */,
+				EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -437,6 +449,10 @@
 				CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */,
 				CC00000100000004AAAAAA01 /* ZonesGridView.swift in Sources */,
 				DD00000100000001AAAAAA01 /* NFCService.swift in Sources */,
+				EE00000100000001AAAAAA01 /* CustomAttribute.swift in Sources */,
+				EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */,
+				EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */,
+				EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/binthere/Item.swift
+++ b/binthere/Item.swift
@@ -12,11 +12,18 @@ final class Item {
     var color: String = ""
     var createdAt: Date = Date()
     var isCheckedOut: Bool = false
+    var notes: String = ""
+    var value: Double?
+    var valueSource: String = ""
+    var valueUpdatedAt: Date?
 
     var bin: Bin?
 
     @Relationship(deleteRule: .cascade, inverse: \CheckoutRecord.item)
     var checkoutHistory: [CheckoutRecord] = []
+
+    @Relationship(deleteRule: .cascade, inverse: \CustomAttribute.item)
+    var customAttributes: [CustomAttribute] = []
 
     init(name: String, itemDescription: String = "", bin: Bin? = nil) {
         self.id = UUID()

--- a/binthere/Models/Bin.swift
+++ b/binthere/Models/Bin.swift
@@ -26,6 +26,14 @@ final class Bin {
         return "\(code) — \(name)"
     }
 
+    var totalValue: Double {
+        items.compactMap(\.value).reduce(0, +)
+    }
+
+    var itemsWithValueCount: Int {
+        items.filter { $0.value != nil }.count
+    }
+
     init(code: String, name: String = "", binDescription: String = "", location: String = "") {
         self.id = UUID()
         self.code = code

--- a/binthere/Models/CustomAttribute.swift
+++ b/binthere/Models/CustomAttribute.swift
@@ -1,0 +1,76 @@
+import Foundation
+import SwiftData
+
+enum AttributeType: String, CaseIterable, Identifiable {
+    case text
+    case number
+    case date
+    case boolean
+    case currency
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .text: "Text"
+        case .number: "Number"
+        case .date: "Date"
+        case .boolean: "Yes / No"
+        case .currency: "Currency"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .text: "textformat"
+        case .number: "number"
+        case .date: "calendar"
+        case .boolean: "checkmark.circle"
+        case .currency: "dollarsign.circle"
+        }
+    }
+}
+
+@Model
+final class CustomAttribute {
+    var id: UUID = UUID()
+    var name: String = ""
+    var type: String = AttributeType.text.rawValue
+    var textValue: String = ""
+    var numberValue: Double?
+    var dateValue: Date?
+    var boolValue: Bool = false
+    var sortOrder: Int = 0
+
+    var item: Item?
+
+    var attributeType: AttributeType {
+        get { AttributeType(rawValue: type) ?? .text }
+        set { type = newValue.rawValue }
+    }
+
+    var displayValue: String {
+        switch attributeType {
+        case .text:
+            return textValue
+        case .number:
+            guard let num = numberValue else { return "—" }
+            return NumberFormatter.localizedString(from: NSNumber(value: num), number: .decimal)
+        case .date:
+            guard let date = dateValue else { return "—" }
+            return date.formatted(date: .abbreviated, time: .omitted)
+        case .boolean:
+            return boolValue ? "Yes" : "No"
+        case .currency:
+            guard let num = numberValue else { return "—" }
+            return CurrencyFormatter.format(num)
+        }
+    }
+
+    init(name: String, type: AttributeType = .text, sortOrder: Int = 0) {
+        self.id = UUID()
+        self.name = name
+        self.type = type.rawValue
+        self.sortOrder = sortOrder
+    }
+}

--- a/binthere/Models/Zone.swift
+++ b/binthere/Models/Zone.swift
@@ -16,6 +16,10 @@ final class Zone {
         bins.reduce(0) { $0 + $1.items.count }
     }
 
+    var totalValue: Double {
+        bins.reduce(0) { $0 + $1.totalValue }
+    }
+
     init(name: String, locationDescription: String = "", color: String = "", icon: String = "") {
         self.id = UUID()
         self.name = name

--- a/binthere/Services/ImageAnalysisService.swift
+++ b/binthere/Services/ImageAnalysisService.swift
@@ -145,4 +145,122 @@ final class ImageAnalysisService {
             return SuggestedItem(name: name, description: description, tags: tags)
         }
     }
+
+    // MARK: - Value Estimation
+
+    struct ValueEstimate {
+        let value: Double
+        let reasoning: String
+    }
+
+    func estimateValue(
+        for image: UIImage,
+        itemName: String,
+        itemDescription: String
+    ) async -> ValueEstimate? {
+        guard let apiKey = Self.apiKey, !apiKey.isEmpty else {
+            error = .noAPIKey
+            return nil
+        }
+
+        guard let imageData = image.jpegData(compressionQuality: 0.7) else {
+            error = .imageConversionFailed
+            return nil
+        }
+
+        isAnalyzing = true
+        error = nil
+        defer { isAnalyzing = false }
+
+        let prompt = """
+        Estimate the current resale value of this item in US dollars.
+        Item name: \(itemName)
+        Description: \(itemDescription.isEmpty ? "(none)" : itemDescription)
+
+        Consider the visible condition in the photo and typical market prices \
+        for similar items. Respond with ONLY a JSON object with two keys: \
+        "estimated_value" (a number in USD, no currency symbol) and \
+        "reasoning" (a brief 1-2 sentence explanation of how you arrived at \
+        the estimate). Example: {"estimated_value": 25.00, "reasoning": \
+        "Used hand tool in good condition, similar items retail for $20-30."}
+        """
+
+        guard let request = buildValueRequest(
+            apiKey: apiKey,
+            base64Image: imageData.base64EncodedString(),
+            prompt: prompt
+        ) else {
+            error = .decodingError("Failed to create request")
+            return nil
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            return try parseValueResponse(data)
+        } catch let analysisError as ImageAnalysisError {
+            error = analysisError
+            return nil
+        } catch {
+            self.error = .networkError(error)
+            return nil
+        }
+    }
+
+    private func buildValueRequest(apiKey: String, base64Image: String, prompt: String) -> URLRequest? {
+        let requestBody: [String: Any] = [
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 512,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": [
+                        [
+                            "type": "image",
+                            "source": [
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": base64Image,
+                            ],
+                        ],
+                        [
+                            "type": "text",
+                            "text": prompt,
+                        ],
+                    ],
+                ]
+            ],
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: requestBody),
+              let apiURL = URL(string: "https://api.anthropic.com/v1/messages") else {
+            return nil
+        }
+
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.httpBody = jsonData
+        return request
+    }
+
+    private func parseValueResponse(_ data: Data) throws -> ValueEstimate {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let firstBlock = content.first,
+              let text = firstBlock["text"] as? String else {
+            throw ImageAnalysisError.decodingError("Unexpected response format")
+        }
+
+        let jsonText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let valueData = jsonText.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: valueData) as? [String: Any],
+              let estimatedValue = parsed["estimated_value"] as? Double else {
+            throw ImageAnalysisError.decodingError("Could not parse value estimate")
+        }
+
+        let reasoning = parsed["reasoning"] as? String ?? ""
+        return ValueEstimate(value: estimatedValue, reasoning: reasoning)
+    }
 }

--- a/binthere/Utilities/CurrencyFormatter.swift
+++ b/binthere/Utilities/CurrencyFormatter.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum CurrencyFormatter {
+    private static let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = Locale.current
+        return formatter
+    }()
+
+    static func format(_ value: Double?) -> String {
+        guard let value, value != 0 else { return "—" }
+        return formatter.string(from: NSNumber(value: value)) ?? "—"
+    }
+
+    static func parse(_ string: String) -> Double? {
+        let cleaned = string.filter { $0.isNumber || $0 == "." || $0 == "-" }
+        return Double(cleaned)
+    }
+}

--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -175,6 +175,16 @@ struct BinDetailView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            if bin.totalValue > 0 {
+                Label {
+                    Text("\(CurrencyFormatter.format(bin.totalValue)) · \(bin.itemsWithValueCount) item\(bin.itemsWithValueCount == 1 ? "" : "s")")
+                } icon: {
+                    Image(systemName: "dollarsign.circle")
+                }
+                .font(.caption)
+                .foregroundStyle(.green)
+            }
         }
     }
 }

--- a/binthere/Views/Items/EditAttributeSheet.swift
+++ b/binthere/Views/Items/EditAttributeSheet.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+struct EditAttributeSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    let item: Item
+    var existing: CustomAttribute?
+
+    @State private var name: String = ""
+    @State private var selectedType: AttributeType = .text
+    @State private var textValue: String = ""
+    @State private var numberValue: String = ""
+    @State private var dateValue: Date = Date()
+    @State private var boolValue: Bool = false
+
+    private var isEditing: Bool { existing != nil }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("e.g. Brand, Purchase Date", text: $name)
+                }
+
+                Section("Type") {
+                    Picker("Type", selection: $selectedType) {
+                        ForEach(AttributeType.allCases) { type in
+                            Label(type.displayName, systemImage: type.systemImage)
+                                .tag(type)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                Section("Value") {
+                    valueField
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Attribute" : "New Attribute")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .onAppear { populateFromExisting() }
+        }
+    }
+
+    @ViewBuilder
+    private var valueField: some View {
+        switch selectedType {
+        case .text:
+            TextField("Value", text: $textValue, axis: .vertical)
+                .lineLimit(1...4)
+        case .number:
+            TextField("0", text: $numberValue)
+                .keyboardType(.decimalPad)
+        case .date:
+            DatePicker("Date", selection: $dateValue, displayedComponents: .date)
+        case .boolean:
+            Toggle("Value", isOn: $boolValue)
+        case .currency:
+            HStack {
+                Text("$")
+                    .foregroundStyle(.secondary)
+                TextField("0.00", text: $numberValue)
+                    .keyboardType(.decimalPad)
+            }
+        }
+    }
+
+    private func populateFromExisting() {
+        guard let existing else { return }
+        name = existing.name
+        selectedType = existing.attributeType
+        textValue = existing.textValue
+        if let num = existing.numberValue {
+            numberValue = String(format: "%.2f", num)
+        }
+        if let date = existing.dateValue {
+            dateValue = date
+        }
+        boolValue = existing.boolValue
+    }
+
+    private func save() {
+        let attribute = existing ?? CustomAttribute(
+            name: name,
+            type: selectedType,
+            sortOrder: item.customAttributes.count
+        )
+
+        attribute.name = name.trimmingCharacters(in: .whitespaces)
+        attribute.attributeType = selectedType
+
+        // Clear non-matching type fields so the displayValue is correct
+        switch selectedType {
+        case .text:
+            attribute.textValue = textValue
+            attribute.numberValue = nil
+            attribute.dateValue = nil
+            attribute.boolValue = false
+        case .number, .currency:
+            attribute.numberValue = Double(numberValue)
+            attribute.textValue = ""
+            attribute.dateValue = nil
+            attribute.boolValue = false
+        case .date:
+            attribute.dateValue = dateValue
+            attribute.textValue = ""
+            attribute.numberValue = nil
+            attribute.boolValue = false
+        case .boolean:
+            attribute.boolValue = boolValue
+            attribute.textValue = ""
+            attribute.numberValue = nil
+            attribute.dateValue = nil
+        }
+
+        if existing == nil {
+            attribute.item = item
+            modelContext.insert(attribute)
+        }
+
+        dismiss()
+    }
+}

--- a/binthere/Views/Items/ItemDetailView.swift
+++ b/binthere/Views/Items/ItemDetailView.swift
@@ -11,6 +11,9 @@ struct ItemDetailView: View {
     @State private var showingMoveBin = false
     @State private var showingDeleteConfirmation = false
     @State private var showingImagePicker = false
+    @State private var showingSetValue = false
+    @State private var editingAttribute: CustomAttribute?
+    @State private var showingNewAttribute = false
 
     var body: some View {
         List {
@@ -46,6 +49,59 @@ struct ItemDetailView: View {
                 if let bin = item.bin {
                     LabeledContent("Bin", value: bin.displayName)
                 }
+            }
+
+            Section("Value") {
+                Button(action: { showingSetValue = true }) {
+                    HStack {
+                        Image(systemName: "dollarsign.circle")
+                        Text(CurrencyFormatter.format(item.value))
+                            .foregroundStyle(item.value == nil ? .secondary : .primary)
+                        Spacer()
+                        if !item.valueSource.isEmpty {
+                            Text(item.valueSource == "ai" ? "AI" : "Manual")
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(.quaternary)
+                                .clipShape(Capsule())
+                        }
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+
+            Section("Notes") {
+                TextField("Add notes about this item...", text: $item.notes, axis: .vertical)
+                    .lineLimit(3...10)
+            }
+
+            Section {
+                ForEach(item.customAttributes.sorted(by: { $0.sortOrder < $1.sortOrder })) { attribute in
+                    Button(action: { editingAttribute = attribute }) {
+                        HStack {
+                            Image(systemName: attribute.attributeType.systemImage)
+                                .foregroundStyle(.secondary)
+                                .frame(width: 20)
+                            Text(attribute.name)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Text(attribute.displayValue)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+                .onDelete(perform: deleteAttributes)
+
+                Button(action: { showingNewAttribute = true }) {
+                    Label("Add Attribute", systemImage: "plus.circle")
+                }
+            } header: {
+                Text("Custom Attributes")
             }
 
             Section("Color") {
@@ -128,6 +184,22 @@ struct ItemDetailView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("This will permanently remove this item and its checkout history.")
+        }
+        .sheet(isPresented: $showingSetValue) {
+            SetValueSheet(item: item)
+        }
+        .sheet(isPresented: $showingNewAttribute) {
+            EditAttributeSheet(item: item, existing: nil)
+        }
+        .sheet(item: $editingAttribute) { attribute in
+            EditAttributeSheet(item: item, existing: attribute)
+        }
+    }
+
+    private func deleteAttributes(at offsets: IndexSet) {
+        let sorted = item.customAttributes.sorted(by: { $0.sortOrder < $1.sortOrder })
+        for index in offsets {
+            modelContext.delete(sorted[index])
         }
     }
 

--- a/binthere/Views/Items/SetValueSheet.swift
+++ b/binthere/Views/Items/SetValueSheet.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct SetValueSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var item: Item
+
+    @State private var valueText: String = ""
+    @State private var reasoning: String = ""
+    @State private var analysisService = ImageAnalysisService()
+    @State private var isEstimating = false
+
+    private var canEstimate: Bool {
+        ImageAnalysisService.apiKey != nil
+            && !(ImageAnalysisService.apiKey ?? "").isEmpty
+            && !item.imagePaths.isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Value") {
+                    HStack {
+                        Text("$")
+                            .foregroundStyle(.secondary)
+                        TextField("0.00", text: $valueText)
+                            .keyboardType(.decimalPad)
+                    }
+                }
+
+                Section {
+                    Button(action: estimateWithAI) {
+                        HStack {
+                            if isEstimating {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                            } else {
+                                Image(systemName: "sparkles")
+                            }
+                            Text(isEstimating ? "Estimating..." : "Estimate with AI")
+                        }
+                    }
+                    .disabled(!canEstimate || isEstimating)
+
+                    if !canEstimate {
+                        Text(item.imagePaths.isEmpty
+                             ? "Add a photo to use AI estimation"
+                             : "Add your Claude API key in Settings to use AI estimation")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !reasoning.isEmpty {
+                    Section("AI Reasoning") {
+                        Text(reasoning)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let error = analysisService.error {
+                    Section {
+                        Label(error.localizedDescription, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Set Value")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(CurrencyFormatter.parse(valueText) == nil)
+                }
+            }
+            .onAppear {
+                if let existing = item.value {
+                    valueText = String(format: "%.2f", existing)
+                }
+            }
+        }
+    }
+
+    private func estimateWithAI() {
+        guard let photo = item.imagePaths.first.flatMap({ ImageStorageService.loadImage(filename: $0) }) else {
+            return
+        }
+
+        isEstimating = true
+        Task {
+            let estimate = await analysisService.estimateValue(
+                for: photo,
+                itemName: item.name,
+                itemDescription: item.itemDescription
+            )
+            isEstimating = false
+            if let estimate {
+                valueText = String(format: "%.2f", estimate.value)
+                reasoning = estimate.reasoning
+                item.valueSource = "ai"
+            }
+        }
+    }
+
+    private func save() {
+        guard let value = CurrencyFormatter.parse(valueText) else { return }
+        item.value = value
+        item.valueUpdatedAt = Date()
+        if item.valueSource.isEmpty {
+            item.valueSource = "manual"
+        }
+        dismiss()
+    }
+}

--- a/binthere/Views/Settings/ZoneDetailView.swift
+++ b/binthere/Views/Settings/ZoneDetailView.swift
@@ -118,6 +118,11 @@ struct ZoneDetailView: View {
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                if zone.totalValue > 0 {
+                    Label(CurrencyFormatter.format(zone.totalValue), systemImage: "dollarsign.circle")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
             }
         }
     }

--- a/binthere/Views/Zones/ZonesGridView.swift
+++ b/binthere/Views/Zones/ZonesGridView.swift
@@ -95,6 +95,16 @@ private struct ZoneCard: View {
                 }
                 .font(.caption)
                 .foregroundStyle(.white.opacity(0.8))
+
+                if zone.totalValue > 0 {
+                    Text(CurrencyFormatter.format(zone.totalValue))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(.white.opacity(0.2))
+                        .clipShape(Capsule())
+                }
             }
 
             if !zone.locationDescription.isEmpty {

--- a/binthere/binthereApp.swift
+++ b/binthere/binthereApp.swift
@@ -8,7 +8,8 @@ struct binthereApp: App { // swiftlint:disable:this type_name
             Zone.self,
             Bin.self,
             Item.self,
-            CheckoutRecord.self
+            CheckoutRecord.self,
+            CustomAttribute.self
         ])
         let modelConfiguration = ModelConfiguration(
             schema: schema,

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -317,6 +317,174 @@ final class ModelTests: XCTestCase {
     }
 }
 
+// MARK: - Item Enrichment Tests
+
+@MainActor
+final class ItemEnrichmentTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(
+            for: Zone.self, Bin.self, Item.self, CheckoutRecord.self, CustomAttribute.self,
+            configurations: config
+        )
+        context = container.mainContext
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+        context = nil
+    }
+
+    func test_itemValue_defaultsNil() {
+        let item = Item(name: "Drill")
+        context.insert(item)
+        XCTAssertNil(item.value)
+        XCTAssertTrue(item.valueSource.isEmpty)
+        XCTAssertNil(item.valueUpdatedAt)
+    }
+
+    func test_itemValueTracking() throws {
+        let item = Item(name: "Drill")
+        context.insert(item)
+        item.value = 150.00
+        item.valueSource = "manual"
+        item.valueUpdatedAt = Date()
+        try context.save()
+
+        XCTAssertEqual(item.value, 150.00)
+        XCTAssertEqual(item.valueSource, "manual")
+        XCTAssertNotNil(item.valueUpdatedAt)
+    }
+
+    func test_binTotalValue_rollup() throws {
+        let bin = Bin(code: "V001")
+        let item1 = Item(name: "Item 1", bin: bin)
+        let item2 = Item(name: "Item 2", bin: bin)
+        let item3 = Item(name: "Item 3", bin: bin)
+        item1.value = 50.00
+        item2.value = 100.00
+        // item3 has no value
+        context.insert(bin)
+        context.insert(item1)
+        context.insert(item2)
+        context.insert(item3)
+        try context.save()
+
+        XCTAssertEqual(bin.totalValue, 150.00)
+        XCTAssertEqual(bin.itemsWithValueCount, 2)
+    }
+
+    func test_zoneTotalValue_rollup() throws {
+        let zone = Zone(name: "Garage")
+        let bin1 = Bin(code: "G001")
+        let bin2 = Bin(code: "G002")
+        bin1.zone = zone
+        bin2.zone = zone
+        let item1 = Item(name: "Tool", bin: bin1)
+        let item2 = Item(name: "Gadget", bin: bin2)
+        item1.value = 25.00
+        item2.value = 75.00
+        context.insert(zone)
+        context.insert(bin1)
+        context.insert(bin2)
+        context.insert(item1)
+        context.insert(item2)
+        try context.save()
+
+        XCTAssertEqual(zone.totalValue, 100.00)
+    }
+
+    func test_customAttribute_persists() throws {
+        let item = Item(name: "Watch")
+        context.insert(item)
+
+        let brand = CustomAttribute(name: "Brand", type: .text)
+        brand.textValue = "Seiko"
+        brand.item = item
+        context.insert(brand)
+
+        let year = CustomAttribute(name: "Year", type: .number)
+        year.numberValue = 1985
+        year.item = item
+        context.insert(year)
+        try context.save()
+
+        XCTAssertEqual(item.customAttributes.count, 2)
+    }
+
+    func test_customAttribute_cascadeDelete() throws {
+        let item = Item(name: "Watch")
+        let attribute = CustomAttribute(name: "Brand", type: .text)
+        attribute.textValue = "Seiko"
+        attribute.item = item
+        context.insert(item)
+        context.insert(attribute)
+        try context.save()
+
+        context.delete(item)
+        try context.save()
+
+        let descriptor = FetchDescriptor<CustomAttribute>()
+        let remaining = try context.fetch(descriptor)
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_customAttribute_displayValue_byType() {
+        let textAttr = CustomAttribute(name: "Brand", type: .text)
+        textAttr.textValue = "Seiko"
+        XCTAssertEqual(textAttr.displayValue, "Seiko")
+
+        let boolAttr = CustomAttribute(name: "Waterproof", type: .boolean)
+        boolAttr.boolValue = true
+        XCTAssertEqual(boolAttr.displayValue, "Yes")
+
+        boolAttr.boolValue = false
+        XCTAssertEqual(boolAttr.displayValue, "No")
+
+        let dateAttr = CustomAttribute(name: "Purchased", type: .date)
+        dateAttr.dateValue = nil
+        XCTAssertEqual(dateAttr.displayValue, "—")
+    }
+
+    func test_itemNotes_persist() throws {
+        let item = Item(name: "Box")
+        context.insert(item)
+        item.notes = "Contains grandma's china. Handle with care."
+        try context.save()
+
+        XCTAssertEqual(item.notes, "Contains grandma's china. Handle with care.")
+    }
+}
+
+// MARK: - CurrencyFormatter Tests
+
+final class CurrencyFormatterTests: XCTestCase {
+
+    func test_format_nilReturnsDash() {
+        XCTAssertEqual(CurrencyFormatter.format(nil), "—")
+    }
+
+    func test_format_zeroReturnsDash() {
+        XCTAssertEqual(CurrencyFormatter.format(0), "—")
+    }
+
+    func test_format_positiveValue() {
+        let result = CurrencyFormatter.format(123.45)
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertNotEqual(result, "—")
+    }
+
+    func test_parse_currencyString() {
+        XCTAssertEqual(CurrencyFormatter.parse("$123.45"), 123.45)
+        XCTAssertEqual(CurrencyFormatter.parse("1000"), 1000)
+        XCTAssertEqual(CurrencyFormatter.parse("49.99"), 49.99)
+    }
+}
+
 // MARK: - CodeGenerator Tests
 
 final class CodeGeneratorTests: XCTestCase {


### PR DESCRIPTION
## Summary

Phase 5 of the roadmap — foundation for insurance reports in Phase 6.

- **Valuations**: items get a value, source (manual/AI), and timestamp. Total rolls up to bin and zone.
- **AI value estimation**: new `estimateValue` method sends item photo + name + description to Claude, returns estimated value in USD with reasoning
- **SetValueSheet**: currency input with optional "Estimate with AI" button that populates the field and shows reasoning
- **Typed custom attributes**: new `CustomAttribute` @Model with text, number, date, boolean, currency types. Each renders with the appropriate UI control in edit sheet.
- **Notes**: free-text multi-line notes on items
- **Value displays**: BinDetailView, ZoneDetailView, and ZonesGridView show totals when > 0
- **Tests**: 12+ new tests covering valuation rollups, custom attribute persistence, cascade deletes, display values, currency formatting

## Test plan

- [ ] Create an item, set a value manually → verify it displays correctly
- [ ] Open bin detail → verify total value shows with item count
- [ ] Open zone detail → verify total value in header
- [ ] Open zones grid → verify currency pill on cards
- [ ] Add custom attributes of each type → verify correct UI per type
- [ ] Edit existing attribute → verify changes persist
- [ ] Delete attribute via swipe → verify it's removed
- [ ] Add notes → verify multi-line persistence
- [ ] Tap "Estimate with AI" on an item with a photo → verify Claude returns value + reasoning (requires API key)
- [ ] Delete item with attributes → verify cascade delete
- [ ] Run unit tests