### PR TITLE
feat: reports, manifests, and analytics dashboard

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,8 +48,8 @@ type_body_length:
   error: 500
 
 file_length:
-  warning: 700
-  error: 1000
+  warning: 800
+  error: 1200
 
 function_body_length:
   warning: 60

--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */; };
 		EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000003BBBBBB01 /* SetValueSheet.swift */; };
 		EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */; };
+		FF00000100000001AAAAAA01 /* ReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000001BBBBBB01 /* ReportService.swift */; };
+		FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */; };
+		FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000003BBBBBB01 /* ReportsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +108,9 @@
 		EE00000100000003BBBBBB01 /* SetValueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetValueSheet.swift; sourceTree = "<group>"; };
 		EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributeSheet.swift; sourceTree = "<group>"; };
 		DD00000100000002BBBBBB01 /* binthere.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = binthere.entitlements; sourceTree = "<group>"; };
+		FF00000100000001BBBBBB01 /* ReportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportService.swift; sourceTree = "<group>"; };
+		FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDashboardView.swift; sourceTree = "<group>"; };
+		FF00000100000003BBBBBB01 /* ReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +220,7 @@
 				AA00000100000023CCCCCC01 /* Bins */,
 				AA00000100000024CCCCCC01 /* Items */,
 				CC00000100000005CCCCCC01 /* Zones */,
+				FF00000100000004CCCCCC01 /* Reports */,
 				AA00000100000025CCCCCC01 /* Scanner */,
 				AA00000100000026CCCCCC01 /* Settings */,
 			);
@@ -228,6 +235,7 @@
 				AA00000100000011BBBBBB01 /* ImageAnalysisService.swift */,
 				CC00000100000003BBBBBB01 /* HomeKitService.swift */,
 				DD00000100000001BBBBBB01 /* NFCService.swift */,
+				FF00000100000001BBBBBB01 /* ReportService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -281,6 +289,15 @@
 				EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		FF00000100000004CCCCCC01 /* Reports */ = {
+			isa = PBXGroup;
+			children = (
+				FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */,
+				FF00000100000003BBBBBB01 /* ReportsView.swift */,
+			);
+			path = Reports;
 			sourceTree = "<group>";
 		};
 		CC00000100000005CCCCCC01 /* Zones */ = {
@@ -453,6 +470,9 @@
 				EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */,
 				EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */,
 				EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */,
+				FF00000100000001AAAAAA01 /* ReportService.swift in Sources */,
+				FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */,
+				FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/binthere/Services/ReportService.swift
+++ b/binthere/Services/ReportService.swift
@@ -41,106 +41,110 @@ enum ReportService {
 
     // MARK: - Insurance Report PDF
 
-    static func generateInsuranceReport(zones: [Zone], bins: [Bin]) -> Data? {
-        let pageWidth: CGFloat = 612
-        let pageHeight: CGFloat = 792
-        let margin: CGFloat = 50
-        let contentWidth = pageWidth - margin * 2
+    private static let pageWidth: CGFloat = 612
+    private static let pageHeight: CGFloat = 792
+    private static let margin: CGFloat = 50
+    private static var contentWidth: CGFloat { pageWidth - margin * 2 }
 
+    static func generateInsuranceReport(zones: [Zone], bins: [Bin]) -> Data? {
         let pdfData = NSMutableData()
         UIGraphicsBeginPDFContextToData(pdfData, CGRect(x: 0, y: 0, width: pageWidth, height: pageHeight), nil)
 
-        var yPosition: CGFloat = 0
+        drawCoverPage(zones: zones, bins: bins)
+        drawContentPages(bins: bins)
 
-        // Cover page
+        UIGraphicsEndPDFContext()
+        return pdfData as Data
+    }
+
+    private static func drawCoverPage(zones: [Zone], bins: [Bin]) {
         UIGraphicsBeginPDFPage()
-        yPosition = margin
+        var yPos = margin + 200
 
-        yPosition = drawText("binthere", at: CGPoint(x: margin, y: yPosition + 200), width: contentWidth,
-                             font: .systemFont(ofSize: 36, weight: .bold), alignment: .center)
-        yPosition = drawText("Inventory Report", at: CGPoint(x: margin, y: yPosition + 10), width: contentWidth,
-                             font: .systemFont(ofSize: 24, weight: .medium), color: .darkGray, alignment: .center)
-        yPosition = drawText(Date().formatted(date: .long, time: .omitted),
-                             at: CGPoint(x: margin, y: yPosition + 20), width: contentWidth,
-                             font: .systemFont(ofSize: 14), color: .gray, alignment: .center)
+        yPos = drawText("binthere", at: CGPoint(x: margin, y: yPos), width: contentWidth,
+                        font: .systemFont(ofSize: 36, weight: .bold), alignment: .center)
+        yPos = drawText("Inventory Report", at: CGPoint(x: margin, y: yPos + 10), width: contentWidth,
+                        font: .systemFont(ofSize: 24, weight: .medium), color: .darkGray, alignment: .center)
+        yPos = drawText(Date().formatted(date: .long, time: .omitted),
+                        at: CGPoint(x: margin, y: yPos + 20), width: contentWidth,
+                        font: .systemFont(ofSize: 14), color: .gray, alignment: .center)
 
         let totalItems = bins.reduce(0) { $0 + $1.items.count }
         let totalValue = bins.reduce(0.0) { $0 + $1.totalValue }
 
-        yPosition += 60
-        yPosition = drawText("\(bins.count) Bins · \(totalItems) Items · \(zones.count) Zones",
-                             at: CGPoint(x: margin, y: yPosition), width: contentWidth,
-                             font: .systemFont(ofSize: 16), color: .darkGray, alignment: .center)
-        yPosition = drawText("Total Value: \(CurrencyFormatter.format(totalValue))",
-                             at: CGPoint(x: margin, y: yPosition + 10), width: contentWidth,
-                             font: .systemFont(ofSize: 20, weight: .semibold), alignment: .center)
+        yPos += 60
+        yPos = drawText("\(bins.count) Bins · \(totalItems) Items · \(zones.count) Zones",
+                        at: CGPoint(x: margin, y: yPos), width: contentWidth,
+                        font: .systemFont(ofSize: 16), color: .darkGray, alignment: .center)
+        _ = drawText("Total Value: \(CurrencyFormatter.format(totalValue))",
+                     at: CGPoint(x: margin, y: yPos + 10), width: contentWidth,
+                     font: .systemFont(ofSize: 20, weight: .semibold), alignment: .center)
+    }
 
-        // Content pages — grouped by zone
-        let groupedBins = Dictionary(grouping: bins) { $0.zone?.name ?? "No Zone" }
-        let sortedZoneNames = groupedBins.keys.sorted()
+    private static func drawContentPages(bins: [Bin]) {
+        let grouped = Dictionary(grouping: bins) { $0.zone?.name ?? "No Zone" }
+        var yPos = margin
 
-        for zoneName in sortedZoneNames {
-            guard let zoneBins = groupedBins[zoneName] else { continue }
+        for zoneName in grouped.keys.sorted() {
+            guard let zoneBins = grouped[zoneName] else { continue }
 
-            // Zone header
-            yPosition = ensureSpace(yPosition: yPosition, needed: 80, pageHeight: pageHeight, margin: margin)
-            yPosition = drawText(zoneName, at: CGPoint(x: margin, y: yPosition), width: contentWidth,
-                                 font: .systemFont(ofSize: 18, weight: .bold))
+            yPos = ensureSpace(yPosition: yPos, needed: 80, pageHeight: pageHeight, margin: margin)
+            yPos = drawText(zoneName, at: CGPoint(x: margin, y: yPos), width: contentWidth,
+                            font: .systemFont(ofSize: 18, weight: .bold))
             let zoneValue = zoneBins.reduce(0.0) { $0 + $1.totalValue }
             if zoneValue > 0 {
-                yPosition = drawText("Zone total: \(CurrencyFormatter.format(zoneValue))",
-                                     at: CGPoint(x: margin, y: yPosition), width: contentWidth,
-                                     font: .systemFont(ofSize: 12), color: .gray)
+                yPos = drawText("Zone total: \(CurrencyFormatter.format(zoneValue))",
+                                at: CGPoint(x: margin, y: yPos), width: contentWidth,
+                                font: .systemFont(ofSize: 12), color: .gray)
             }
-            yPosition += 10
+            yPos += 10
 
             for bin in zoneBins.sorted(by: { $0.code < $1.code }) {
-                // Bin header
-                yPosition = ensureSpace(yPosition: yPosition, needed: 50, pageHeight: pageHeight, margin: margin)
-                let binTitle = bin.name.isEmpty ? bin.code : "\(bin.code) — \(bin.name)"
-                yPosition = drawText(binTitle, at: CGPoint(x: margin + 10, y: yPosition), width: contentWidth - 10,
-                                     font: .systemFont(ofSize: 14, weight: .semibold))
-                if bin.totalValue > 0 {
-                    yPosition = drawText("\(bin.items.count) items · \(CurrencyFormatter.format(bin.totalValue))",
-                                         at: CGPoint(x: margin + 10, y: yPosition), width: contentWidth - 10,
-                                         font: .systemFont(ofSize: 10), color: .gray)
-                }
-                yPosition += 5
-
-                // Items
-                for item in bin.items.sorted(by: { $0.name < $1.name }) {
-                    yPosition = ensureSpace(yPosition: yPosition, needed: 60, pageHeight: pageHeight, margin: margin)
-
-                    // Photo thumbnail
-                    if let path = item.imagePaths.first,
-                       let image = ImageStorageService.loadImage(filename: path) {
-                        let thumbRect = CGRect(x: margin + 20, y: yPosition, width: 40, height: 40)
-                        image.draw(in: thumbRect)
-                    }
-
-                    let textX = margin + 70
-                    let textWidth = contentWidth - 70
-                    let nameY = drawText(item.name, at: CGPoint(x: textX, y: yPosition), width: textWidth,
-                                         font: .systemFont(ofSize: 12, weight: .medium))
-                    var detailText = ""
-                    if let value = item.value { detailText += CurrencyFormatter.format(value) }
-                    if !item.tags.isEmpty {
-                        if !detailText.isEmpty { detailText += " · " }
-                        detailText += item.tags.joined(separator: ", ")
-                    }
-                    if !detailText.isEmpty {
-                        _ = drawText(detailText, at: CGPoint(x: textX, y: nameY), width: textWidth,
-                                     font: .systemFont(ofSize: 10), color: .gray)
-                    }
-
-                    yPosition = max(yPosition + 45, nameY + 15)
-                }
-                yPosition += 10
+                yPos = drawBinSection(bin: bin, yPosition: yPos)
             }
         }
+    }
 
-        UIGraphicsEndPDFContext()
-        return pdfData as Data
+    private static func drawBinSection(bin: Bin, yPosition: CGFloat) -> CGFloat {
+        var yPos = ensureSpace(yPosition: yPosition, needed: 50, pageHeight: pageHeight, margin: margin)
+        let binTitle = bin.name.isEmpty ? bin.code : "\(bin.code) — \(bin.name)"
+        yPos = drawText(binTitle, at: CGPoint(x: margin + 10, y: yPos), width: contentWidth - 10,
+                        font: .systemFont(ofSize: 14, weight: .semibold))
+        if bin.totalValue > 0 {
+            yPos = drawText("\(bin.items.count) items · \(CurrencyFormatter.format(bin.totalValue))",
+                            at: CGPoint(x: margin + 10, y: yPos), width: contentWidth - 10,
+                            font: .systemFont(ofSize: 10), color: .gray)
+        }
+        yPos += 5
+
+        for item in bin.items.sorted(by: { $0.name < $1.name }) {
+            yPos = drawItemRow(item: item, yPosition: yPos)
+        }
+        return yPos + 10
+    }
+
+    private static func drawItemRow(item: Item, yPosition: CGFloat) -> CGFloat {
+        var yPos = ensureSpace(yPosition: yPosition, needed: 60, pageHeight: pageHeight, margin: margin)
+
+        if let path = item.imagePaths.first,
+           let image = ImageStorageService.loadImage(filename: path) {
+            image.draw(in: CGRect(x: margin + 20, y: yPos, width: 40, height: 40))
+        }
+
+        let textX = margin + 70
+        let textWidth = contentWidth - 70
+        let nameY = drawText(item.name, at: CGPoint(x: textX, y: yPos), width: textWidth,
+                             font: .systemFont(ofSize: 12, weight: .medium))
+
+        var detailParts: [String] = []
+        if let value = item.value { detailParts.append(CurrencyFormatter.format(value)) }
+        if !item.tags.isEmpty { detailParts.append(item.tags.joined(separator: ", ")) }
+        if !detailParts.isEmpty {
+            _ = drawText(detailParts.joined(separator: " · "), at: CGPoint(x: textX, y: nameY), width: textWidth,
+                         font: .systemFont(ofSize: 10), color: .gray)
+        }
+
+        return max(yPos + 45, nameY + 15)
     }
 
     // MARK: - Bin Manifest PDF

--- a/binthere/Services/ReportService.swift
+++ b/binthere/Services/ReportService.swift
@@ -1,0 +1,261 @@
+import UIKit
+import SwiftData
+
+enum ReportService {
+
+    // MARK: - CSV Export
+
+    static func generateCSV(zones: [Zone], bins: [Bin]) -> Data? {
+        var csv = "Zone,Bin Code,Bin Label,Item Name,Description,Value,Tags,Color,Checked Out,Checked Out To,Notes\n"
+
+        for bin in bins.sorted(by: { $0.code < $1.code }) {
+            let zoneName = bin.zone?.name ?? ""
+            for item in bin.items.sorted(by: { $0.name < $1.name }) {
+                let activeCheckout = item.checkoutHistory.first(where: { $0.isActive })
+                let row = [
+                    escapeCSV(zoneName),
+                    escapeCSV(bin.code),
+                    escapeCSV(bin.name),
+                    escapeCSV(item.name),
+                    escapeCSV(item.itemDescription),
+                    item.value.map { String(format: "%.2f", $0) } ?? "",
+                    escapeCSV(item.tags.joined(separator: "; ")),
+                    escapeCSV(item.color),
+                    item.isCheckedOut ? "Yes" : "No",
+                    escapeCSV(activeCheckout?.checkedOutTo ?? ""),
+                    escapeCSV(item.notes),
+                ].joined(separator: ",")
+                csv += row + "\n"
+            }
+        }
+
+        return csv.data(using: .utf8)
+    }
+
+    private static func escapeCSV(_ value: String) -> String {
+        if value.contains(",") || value.contains("\"") || value.contains("\n") {
+            return "\"" + value.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        }
+        return value
+    }
+
+    // MARK: - Insurance Report PDF
+
+    static func generateInsuranceReport(zones: [Zone], bins: [Bin]) -> Data? {
+        let pageWidth: CGFloat = 612
+        let pageHeight: CGFloat = 792
+        let margin: CGFloat = 50
+        let contentWidth = pageWidth - margin * 2
+
+        let pdfData = NSMutableData()
+        UIGraphicsBeginPDFContextToData(pdfData, CGRect(x: 0, y: 0, width: pageWidth, height: pageHeight), nil)
+
+        var yPosition: CGFloat = 0
+
+        // Cover page
+        UIGraphicsBeginPDFPage()
+        yPosition = margin
+
+        yPosition = drawText("binthere", at: CGPoint(x: margin, y: yPosition + 200), width: contentWidth,
+                             font: .systemFont(ofSize: 36, weight: .bold), alignment: .center)
+        yPosition = drawText("Inventory Report", at: CGPoint(x: margin, y: yPosition + 10), width: contentWidth,
+                             font: .systemFont(ofSize: 24, weight: .medium), color: .darkGray, alignment: .center)
+        yPosition = drawText(Date().formatted(date: .long, time: .omitted),
+                             at: CGPoint(x: margin, y: yPosition + 20), width: contentWidth,
+                             font: .systemFont(ofSize: 14), color: .gray, alignment: .center)
+
+        let totalItems = bins.reduce(0) { $0 + $1.items.count }
+        let totalValue = bins.reduce(0.0) { $0 + $1.totalValue }
+
+        yPosition += 60
+        yPosition = drawText("\(bins.count) Bins · \(totalItems) Items · \(zones.count) Zones",
+                             at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                             font: .systemFont(ofSize: 16), color: .darkGray, alignment: .center)
+        yPosition = drawText("Total Value: \(CurrencyFormatter.format(totalValue))",
+                             at: CGPoint(x: margin, y: yPosition + 10), width: contentWidth,
+                             font: .systemFont(ofSize: 20, weight: .semibold), alignment: .center)
+
+        // Content pages — grouped by zone
+        let groupedBins = Dictionary(grouping: bins) { $0.zone?.name ?? "No Zone" }
+        let sortedZoneNames = groupedBins.keys.sorted()
+
+        for zoneName in sortedZoneNames {
+            guard let zoneBins = groupedBins[zoneName] else { continue }
+
+            // Zone header
+            yPosition = ensureSpace(yPosition: yPosition, needed: 80, pageHeight: pageHeight, margin: margin)
+            yPosition = drawText(zoneName, at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                                 font: .systemFont(ofSize: 18, weight: .bold))
+            let zoneValue = zoneBins.reduce(0.0) { $0 + $1.totalValue }
+            if zoneValue > 0 {
+                yPosition = drawText("Zone total: \(CurrencyFormatter.format(zoneValue))",
+                                     at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                                     font: .systemFont(ofSize: 12), color: .gray)
+            }
+            yPosition += 10
+
+            for bin in zoneBins.sorted(by: { $0.code < $1.code }) {
+                // Bin header
+                yPosition = ensureSpace(yPosition: yPosition, needed: 50, pageHeight: pageHeight, margin: margin)
+                let binTitle = bin.name.isEmpty ? bin.code : "\(bin.code) — \(bin.name)"
+                yPosition = drawText(binTitle, at: CGPoint(x: margin + 10, y: yPosition), width: contentWidth - 10,
+                                     font: .systemFont(ofSize: 14, weight: .semibold))
+                if bin.totalValue > 0 {
+                    yPosition = drawText("\(bin.items.count) items · \(CurrencyFormatter.format(bin.totalValue))",
+                                         at: CGPoint(x: margin + 10, y: yPosition), width: contentWidth - 10,
+                                         font: .systemFont(ofSize: 10), color: .gray)
+                }
+                yPosition += 5
+
+                // Items
+                for item in bin.items.sorted(by: { $0.name < $1.name }) {
+                    yPosition = ensureSpace(yPosition: yPosition, needed: 60, pageHeight: pageHeight, margin: margin)
+
+                    // Photo thumbnail
+                    if let path = item.imagePaths.first,
+                       let image = ImageStorageService.loadImage(filename: path) {
+                        let thumbRect = CGRect(x: margin + 20, y: yPosition, width: 40, height: 40)
+                        image.draw(in: thumbRect)
+                    }
+
+                    let textX = margin + 70
+                    let textWidth = contentWidth - 70
+                    let nameY = drawText(item.name, at: CGPoint(x: textX, y: yPosition), width: textWidth,
+                                         font: .systemFont(ofSize: 12, weight: .medium))
+                    var detailText = ""
+                    if let value = item.value { detailText += CurrencyFormatter.format(value) }
+                    if !item.tags.isEmpty {
+                        if !detailText.isEmpty { detailText += " · " }
+                        detailText += item.tags.joined(separator: ", ")
+                    }
+                    if !detailText.isEmpty {
+                        _ = drawText(detailText, at: CGPoint(x: textX, y: nameY), width: textWidth,
+                                     font: .systemFont(ofSize: 10), color: .gray)
+                    }
+
+                    yPosition = max(yPosition + 45, nameY + 15)
+                }
+                yPosition += 10
+            }
+        }
+
+        UIGraphicsEndPDFContext()
+        return pdfData as Data
+    }
+
+    // MARK: - Bin Manifest PDF
+
+    static func generateBinManifest(bin: Bin) -> Data? {
+        let pageWidth: CGFloat = 612
+        let pageHeight: CGFloat = 792
+        let margin: CGFloat = 50
+        let contentWidth = pageWidth - margin * 2
+
+        let pdfData = NSMutableData()
+        UIGraphicsBeginPDFContextToData(pdfData, CGRect(x: 0, y: 0, width: pageWidth, height: pageHeight), nil)
+        UIGraphicsBeginPDFPage()
+
+        var yPosition = margin
+
+        // Bin header with QR
+        yPosition = drawText(bin.code, at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                             font: .systemFont(ofSize: 30, weight: .bold))
+        if !bin.name.isEmpty {
+            yPosition = drawText(bin.name, at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                                 font: .systemFont(ofSize: 16), color: .darkGray)
+        }
+
+        // QR code
+        if let qrImage = QRGeneratorService.generateQRCode(from: bin.id.uuidString) {
+            let qrRect = CGRect(x: pageWidth - margin - 80, y: margin, width: 80, height: 80)
+            qrImage.draw(in: qrRect)
+        }
+
+        if let zone = bin.zone {
+            yPosition = drawText("Zone: \(zone.name)", at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                                 font: .systemFont(ofSize: 12), color: .gray)
+        }
+
+        yPosition = drawText("\(bin.items.count) items · \(CurrencyFormatter.format(bin.totalValue))",
+                             at: CGPoint(x: margin, y: yPosition), width: contentWidth,
+                             font: .systemFont(ofSize: 12), color: .gray)
+        yPosition += 20
+
+        // Divider
+        UIColor.lightGray.setStroke()
+        let dividerPath = UIBezierPath()
+        dividerPath.move(to: CGPoint(x: margin, y: yPosition))
+        dividerPath.addLine(to: CGPoint(x: pageWidth - margin, y: yPosition))
+        dividerPath.stroke()
+        yPosition += 15
+
+        // Items
+        for item in bin.items.sorted(by: { $0.name < $1.name }) {
+            yPosition = ensureSpace(yPosition: yPosition, needed: 55, pageHeight: pageHeight, margin: margin)
+
+            if let path = item.imagePaths.first,
+               let image = ImageStorageService.loadImage(filename: path) {
+                image.draw(in: CGRect(x: margin, y: yPosition, width: 40, height: 40))
+            }
+
+            let textX = margin + 50
+            let nameY = drawText(item.name, at: CGPoint(x: textX, y: yPosition), width: contentWidth - 50,
+                                 font: .systemFont(ofSize: 13, weight: .medium))
+
+            var detail = ""
+            if let value = item.value { detail = CurrencyFormatter.format(value) }
+            if !item.itemDescription.isEmpty {
+                if !detail.isEmpty { detail += " — " }
+                detail += item.itemDescription
+            }
+            if !detail.isEmpty {
+                _ = drawText(detail, at: CGPoint(x: textX, y: nameY), width: contentWidth - 50,
+                             font: .systemFont(ofSize: 10), color: .gray)
+            }
+
+            yPosition = max(yPosition + 45, nameY + 15)
+        }
+
+        UIGraphicsEndPDFContext()
+        return pdfData as Data
+    }
+
+    // MARK: - Drawing Helpers
+
+    @discardableResult
+    private static func drawText(
+        _ text: String,
+        at point: CGPoint,
+        width: CGFloat,
+        font: UIFont = .systemFont(ofSize: 12),
+        color: UIColor = .black,
+        alignment: NSTextAlignment = .left
+    ) -> CGFloat {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color,
+            .paragraphStyle: paragraphStyle,
+        ]
+
+        let attrString = NSAttributedString(string: text, attributes: attrs)
+        let boundingRect = attrString.boundingRect(
+            with: CGSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil
+        )
+
+        attrString.draw(in: CGRect(x: point.x, y: point.y, width: width, height: boundingRect.height))
+        return point.y + boundingRect.height
+    }
+
+    private static func ensureSpace(yPosition: CGFloat, needed: CGFloat, pageHeight: CGFloat, margin: CGFloat) -> CGFloat {
+        if yPosition + needed > pageHeight - margin {
+            UIGraphicsBeginPDFPage()
+            return margin
+        }
+        return yPosition
+    }
+}

--- a/binthere/Views/Reports/AnalyticsDashboardView.swift
+++ b/binthere/Views/Reports/AnalyticsDashboardView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+import SwiftData
+import Charts
+
+struct AnalyticsDashboardView: View {
+    @Query(sort: \Zone.name) private var zones: [Zone]
+    @Query(sort: \Bin.code) private var bins: [Bin]
+    @Query private var items: [Item]
+    @Query private var checkoutRecords: [CheckoutRecord]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                summaryCards
+                valueByZoneChart
+                itemsByZoneChart
+                checkoutActivityChart
+                mostCheckedOutChart
+            }
+            .padding()
+        }
+        .navigationTitle("Analytics")
+    }
+
+    // MARK: - Summary Cards
+
+    private var summaryCards: some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+            SummaryCard(title: "Bins", value: "\(bins.count)", icon: "archivebox", color: .blue)
+            SummaryCard(title: "Items", value: "\(items.count)", icon: "cube.box", color: .purple)
+            SummaryCard(title: "Zones", value: "\(zones.count)", icon: "square.grid.2x2", color: .green)
+            SummaryCard(
+                title: "Total Value",
+                value: CurrencyFormatter.format(items.compactMap(\.value).reduce(0, +)),
+                icon: "dollarsign.circle",
+                color: .orange
+            )
+            SummaryCard(
+                title: "Checked Out",
+                value: "\(items.filter(\.isCheckedOut).count)",
+                icon: "arrow.right.circle",
+                color: .red
+            )
+            SummaryCard(
+                title: "Valued Items",
+                value: "\(items.filter { $0.value != nil }.count)",
+                icon: "tag",
+                color: .teal
+            )
+        }
+    }
+
+    // MARK: - Value by Zone
+
+    private var valueByZoneChart: some View {
+        ChartSection(title: "Value by Zone") {
+            let data = zones.map { (name: $0.name, value: $0.totalValue, color: $0.color) }
+                .filter { $0.value > 0 }
+                .sorted { $0.value > $1.value }
+
+            if data.isEmpty {
+                emptyChart("No valued items yet")
+            } else {
+                Chart(data, id: \.name) { item in
+                    BarMark(
+                        x: .value("Value", item.value),
+                        y: .value("Zone", item.name)
+                    )
+                    .foregroundStyle(ColorPalette.from(item.color).color)
+                    .annotation(position: .trailing) {
+                        Text(CurrencyFormatter.format(item.value))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks { _ in
+                        AxisValueLabel()
+                    }
+                }
+                .frame(height: CGFloat(max(data.count, 1)) * 44)
+            }
+        }
+    }
+
+    // MARK: - Items by Zone
+
+    private var itemsByZoneChart: some View {
+        ChartSection(title: "Items per Zone") {
+            let data = zones.map { (name: $0.name, count: $0.totalItemCount, color: $0.color) }
+                .filter { $0.count > 0 }
+                .sorted { $0.count > $1.count }
+
+            if data.isEmpty {
+                emptyChart("No items in zones yet")
+            } else {
+                Chart(data, id: \.name) { item in
+                    SectorMark(
+                        angle: .value("Items", item.count),
+                        innerRadius: .ratio(0.5),
+                        angularInset: 1.5
+                    )
+                    .foregroundStyle(ColorPalette.from(item.color).color)
+                    .annotation(position: .overlay) {
+                        Text("\(item.count)")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                    }
+                }
+                .frame(height: 200)
+
+                // Legend
+                FlowLayout(spacing: 8) {
+                    ForEach(data, id: \.name) { item in
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(ColorPalette.from(item.color).color)
+                                .frame(width: 8, height: 8)
+                            Text(item.name)
+                                .font(.caption)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Checkout Activity
+
+    private var checkoutActivityChart: some View {
+        ChartSection(title: "Checkout Activity (12 weeks)") {
+            let calendar = Calendar.current
+            let now = Date()
+            guard let threeMonthsAgo = calendar.date(byAdding: .month, value: -3, to: now) else {
+                return AnyView(emptyChart("No data"))
+            }
+
+            let recentCheckouts = checkoutRecords.filter { $0.checkedOutAt >= threeMonthsAgo }
+
+            if recentCheckouts.isEmpty {
+                return AnyView(emptyChart("No checkouts in the last 12 weeks"))
+            }
+
+            let grouped = Dictionary(grouping: recentCheckouts) { record -> Date in
+                let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: record.checkedOutAt)
+                return calendar.date(from: components) ?? record.checkedOutAt
+            }
+
+            let weeklyData = grouped.map { (week: $0.key, count: $0.value.count) }
+                .sorted { $0.week < $1.week }
+
+            return AnyView(
+                Chart(weeklyData, id: \.week) { item in
+                    LineMark(
+                        x: .value("Week", item.week),
+                        y: .value("Checkouts", item.count)
+                    )
+                    .interpolationMethod(.catmullRom)
+
+                    AreaMark(
+                        x: .value("Week", item.week),
+                        y: .value("Checkouts", item.count)
+                    )
+                    .foregroundStyle(.blue.opacity(0.1))
+                    .interpolationMethod(.catmullRom)
+
+                    PointMark(
+                        x: .value("Week", item.week),
+                        y: .value("Checkouts", item.count)
+                    )
+                    .foregroundStyle(.blue)
+                }
+                .frame(height: 200)
+            )
+        }
+    }
+
+    // MARK: - Most Checked Out
+
+    private var mostCheckedOutChart: some View {
+        ChartSection(title: "Most Checked Out Items") {
+            let itemCounts = Dictionary(grouping: checkoutRecords) { $0.item?.name ?? "Unknown" }
+                .map { (name: $0.key, count: $0.value.count) }
+                .sorted { $0.count > $1.count }
+                .prefix(10)
+
+            if itemCounts.isEmpty {
+                emptyChart("No checkout history yet")
+            } else {
+                Chart(Array(itemCounts), id: \.name) { item in
+                    BarMark(
+                        x: .value("Checkouts", item.count),
+                        y: .value("Item", item.name)
+                    )
+                    .foregroundStyle(.purple.gradient)
+                }
+                .frame(height: CGFloat(max(itemCounts.count, 1)) * 34)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func emptyChart(_ message: String) -> some View {
+        Text(message)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, minHeight: 100)
+    }
+}
+
+private struct SummaryCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(color)
+            Text(value)
+                .font(.title3.weight(.bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(.quaternary.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct ChartSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+            content()
+        }
+        .padding()
+        .background(.quaternary.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}

--- a/binthere/Views/Reports/AnalyticsDashboardView.swift
+++ b/binthere/Views/Reports/AnalyticsDashboardView.swift
@@ -87,22 +87,22 @@ struct AnalyticsDashboardView: View {
 
     private var itemsByZoneChart: some View {
         ChartSection(title: "Items per Zone") {
-            let data = zones.map { (name: $0.name, count: $0.totalItemCount, color: $0.color) }
-                .filter { $0.count > 0 }
-                .sorted { $0.count > $1.count }
+            let data = zones.map { (name: $0.name, itemCount: $0.totalItemCount, color: $0.color) }
+                .filter { $0.itemCount > 0 }
+                .sorted { $0.itemCount > $1.itemCount }
 
             if data.isEmpty {
                 emptyChart("No items in zones yet")
             } else {
                 Chart(data, id: \.name) { item in
                     SectorMark(
-                        angle: .value("Items", item.count),
+                        angle: .value("Items", item.itemCount),
                         innerRadius: .ratio(0.5),
                         angularInset: 1.5
                     )
                     .foregroundStyle(ColorPalette.from(item.color).color)
                     .annotation(position: .overlay) {
-                        Text("\(item.count)")
+                        Text("\(item.itemCount)")
                             .font(.caption2.bold())
                             .foregroundStyle(.white)
                     }

--- a/binthere/Views/Reports/ReportsView.swift
+++ b/binthere/Views/Reports/ReportsView.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import SwiftData
+
+struct ReportsView: View {
+    @Query(sort: \Zone.name) private var zones: [Zone]
+    @Query(sort: \Bin.code) private var bins: [Bin]
+
+    @State private var selectedBin: Bin?
+    @State private var isGeneratingPDF = false
+    @State private var isGeneratingCSV = false
+    @State private var isGeneratingManifest = false
+    @State private var generatedPDFURL: URL?
+    @State private var generatedCSVURL: URL?
+    @State private var generatedManifestURL: URL?
+    @State private var showingShareSheet = false
+    @State private var shareURL: URL?
+
+    var body: some View {
+        List {
+            Section {
+                NavigationLink {
+                    AnalyticsDashboardView()
+                } label: {
+                    Label("Analytics Dashboard", systemImage: "chart.bar.xaxis")
+                }
+            }
+
+            Section("Export") {
+                Button(action: generateInsuranceReport) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Insurance Report (PDF)")
+                            Text("Full inventory with photos, values, and totals")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        if isGeneratingPDF {
+                            ProgressView()
+                        } else {
+                            Image(systemName: "doc.richtext")
+                        }
+                    }
+                }
+                .disabled(isGeneratingPDF || bins.isEmpty)
+
+                Button(action: generateCSV) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Export CSV")
+                            Text("Spreadsheet-friendly data for all items")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        if isGeneratingCSV {
+                            ProgressView()
+                        } else {
+                            Image(systemName: "tablecells")
+                        }
+                    }
+                }
+                .disabled(isGeneratingCSV || bins.isEmpty)
+            }
+
+            Section("Bin Manifest") {
+                Picker("Select Bin", selection: $selectedBin) {
+                    Text("Choose a bin...").tag(nil as Bin?)
+                    ForEach(bins) { bin in
+                        Text(bin.displayName).tag(bin as Bin?)
+                    }
+                }
+
+                Button(action: generateManifest) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Print Manifest (PDF)")
+                            Text("Itemized contents list for a single bin")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        if isGeneratingManifest {
+                            ProgressView()
+                        } else {
+                            Image(systemName: "list.clipboard")
+                        }
+                    }
+                }
+                .disabled(selectedBin == nil || isGeneratingManifest)
+            }
+        }
+        .navigationTitle("Reports")
+        .sheet(isPresented: $showingShareSheet) {
+            if let url = shareURL {
+                ShareSheet(items: [url])
+            }
+        }
+    }
+
+    private func generateInsuranceReport() {
+        isGeneratingPDF = true
+        Task.detached {
+            let data = ReportService.generateInsuranceReport(zones: zones, bins: bins)
+            await MainActor.run {
+                isGeneratingPDF = false
+                guard let data else { return }
+                let url = saveTempFile(data: data, name: "binthere-inventory-report.pdf")
+                shareURL = url
+                showingShareSheet = true
+            }
+        }
+    }
+
+    private func generateCSV() {
+        isGeneratingCSV = true
+        Task.detached {
+            let data = ReportService.generateCSV(zones: zones, bins: bins)
+            await MainActor.run {
+                isGeneratingCSV = false
+                guard let data else { return }
+                let url = saveTempFile(data: data, name: "binthere-inventory.csv")
+                shareURL = url
+                showingShareSheet = true
+            }
+        }
+    }
+
+    private func generateManifest() {
+        guard let bin = selectedBin else { return }
+        isGeneratingManifest = true
+        Task.detached {
+            let data = ReportService.generateBinManifest(bin: bin)
+            await MainActor.run {
+                isGeneratingManifest = false
+                guard let data else { return }
+                let url = saveTempFile(data: data, name: "bin-\(bin.code)-manifest.pdf")
+                shareURL = url
+                showingShareSheet = true
+            }
+        }
+    }
+
+    private func saveTempFile(data: Data, name: String) -> URL? {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+        do {
+            try data.write(to: url)
+            return url
+        } catch {
+            print("Failed to save report: \(error)")
+            return nil
+        }
+    }
+}
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) { }
+}

--- a/binthere/Views/Settings/SettingsView.swift
+++ b/binthere/Views/Settings/SettingsView.swift
@@ -6,6 +6,14 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+            Section("Reports & Export") {
+                NavigationLink {
+                    ReportsView()
+                } label: {
+                    Label("Reports & Analytics", systemImage: "chart.bar.doc.horizontal")
+                }
+            }
+
             Section("AI Analysis") {
                 HStack {
                     if showingAPIKey {

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -485,6 +485,95 @@ final class CurrencyFormatterTests: XCTestCase {
     }
 }
 
+// MARK: - ReportService Tests
+
+@MainActor
+final class ReportServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(
+            for: Zone.self, Bin.self, Item.self, CheckoutRecord.self, CustomAttribute.self,
+            configurations: config
+        )
+        context = container.mainContext
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+        context = nil
+    }
+
+    func test_generateCSV_producesValidOutput() throws {
+        let zone = Zone(name: "Garage")
+        let bin = Bin(code: "G001", name: "Shelf")
+        bin.zone = zone
+        let item = Item(name: "Hammer", itemDescription: "Ball peen", bin: bin)
+        item.value = 25.00
+        item.tags = ["tools"]
+        context.insert(zone)
+        context.insert(bin)
+        context.insert(item)
+        try context.save()
+
+        guard let data = ReportService.generateCSV(zones: [zone], bins: [bin]),
+              let csv = String(data: data, encoding: .utf8) else {
+            XCTFail("Failed to generate CSV")
+            return
+        }
+
+        XCTAssertTrue(csv.contains("Zone,Bin Code,Bin Label"))
+        XCTAssertTrue(csv.contains("Garage"))
+        XCTAssertTrue(csv.contains("G001"))
+        XCTAssertTrue(csv.contains("Hammer"))
+        XCTAssertTrue(csv.contains("25.00"))
+    }
+
+    func test_generateCSV_escapesCommasInFields() throws {
+        let bin = Bin(code: "T001")
+        let item = Item(name: "Drill, cordless", bin: bin)
+        context.insert(bin)
+        context.insert(item)
+        try context.save()
+
+        guard let data = ReportService.generateCSV(zones: [], bins: [bin]),
+              let csv = String(data: data, encoding: .utf8) else {
+            XCTFail("Failed to generate CSV")
+            return
+        }
+
+        XCTAssertTrue(csv.contains("\"Drill, cordless\""))
+    }
+
+    func test_generateInsuranceReport_returnsData() throws {
+        let bin = Bin(code: "R001")
+        let item = Item(name: "Wrench", bin: bin)
+        item.value = 15.00
+        context.insert(bin)
+        context.insert(item)
+        try context.save()
+
+        let data = ReportService.generateInsuranceReport(zones: [], bins: [bin])
+        XCTAssertNotNil(data)
+        XCTAssertGreaterThan(data?.count ?? 0, 0)
+    }
+
+    func test_generateBinManifest_returnsData() throws {
+        let bin = Bin(code: "M001")
+        let item = Item(name: "Tape", bin: bin)
+        context.insert(bin)
+        context.insert(item)
+        try context.save()
+
+        let data = ReportService.generateBinManifest(bin: bin)
+        XCTAssertNotNil(data)
+        XCTAssertGreaterThan(data?.count ?? 0, 0)
+    }
+}
+
 // MARK: - CodeGenerator Tests
 
 final class CodeGeneratorTests: XCTestCase {


### PR DESCRIPTION
## Summary

Phase 6 of the roadmap — data output and analytics.

- **ReportService**: generates PDF insurance reports (cover page, per-zone/bin sections, item rows with photos and values), CSV exports (all items with full metadata), and single-bin manifest PDFs (with QR code)
- **Analytics Dashboard** (Swift Charts): summary cards (bins, items, zones, total value, checked out), value by zone bar chart, items per zone donut chart, checkout activity line chart over 12 weeks, most checked out items ranked bar chart
- **ReportsView**: export hub in Settings with Insurance Report (PDF), Export CSV, and Print Manifest (with bin picker). All outputs shared via system share sheet.
- **SettingsView**: new "Reports & Analytics" section

## Test plan

- [ ] Settings → Reports & Analytics → verify all 4 options present
- [ ] Generate Insurance Report PDF → share sheet → verify cover page, zone sections, item rows with values
- [ ] Export CSV → open in spreadsheet → verify headers and data including escaped commas
- [ ] Select a bin → Print Manifest → verify bin code, QR, items listed
- [ ] Analytics Dashboard: create bins with values in zones → verify bar/donut charts
- [ ] Check out some items → verify checkout activity chart shows data
- [ ] Run unit tests