### PR TITLE
feat: Supabase client setup, database schema, and RLS policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
+      - name: Create Secrets.xcconfig
+        run: |
+          cat > Secrets.xcconfig << EOF
+          SUPABASE_URL = ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY = ${{ secrets.SUPABASE_ANON_KEY }}
+          EOF
       - name: Select latest Xcode
         run: |
           LATEST_XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ Package.pins
 Package.resolved
 
 # Secrets
-*.xcconfig
-!SharedSettings.xcconfig
+Secrets.xcconfig
 .env
 .env.*
 

--- a/Secrets.xcconfig.example
+++ b/Secrets.xcconfig.example
@@ -1,0 +1,6 @@
+// Secrets.xcconfig.example
+// Copy this to Secrets.xcconfig and fill in your Supabase credentials.
+// Secrets.xcconfig is git-ignored — never commit real keys.
+
+SUPABASE_URL = https://YOUR_PROJECT.supabase.co
+SUPABASE_ANON_KEY = your-anon-key-here

--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		FF00000100000001AAAAAA01 /* ReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000001BBBBBB01 /* ReportService.swift */; };
 		FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */; };
 		FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000003BBBBBB01 /* ReportsView.swift */; };
+		AB00000100000001AAAAAA01 /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000001BBBBBB01 /* SupabaseClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		FF00000100000001BBBBBB01 /* ReportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportService.swift; sourceTree = "<group>"; };
 		FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDashboardView.swift; sourceTree = "<group>"; };
 		FF00000100000003BBBBBB01 /* ReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportsView.swift; sourceTree = "<group>"; };
+		AB00000100000001BBBBBB01 /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -236,6 +238,7 @@
 				CC00000100000003BBBBBB01 /* HomeKitService.swift */,
 				DD00000100000001BBBBBB01 /* NFCService.swift */,
 				FF00000100000001BBBBBB01 /* ReportService.swift */,
+				AB00000100000001BBBBBB01 /* SupabaseClient.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -324,6 +327,9 @@
 			dependencies = (
 			);
 			name = binthere;
+			packageProductDependencies = (
+				AABB000100000001DDDDDD01 /* Supabase */,
+			);
 			productName = binthere;
 			productReference = 2FBD3E202BEAC2D100B0C02C /* binthere.app */;
 			productType = "com.apple.product-type.application";
@@ -397,6 +403,9 @@
 			);
 			mainGroup = 2FBD3E172BEAC2D100B0C02C;
 			productRefGroup = 2FBD3E212BEAC2D100B0C02C /* Products */;
+			packageReferences = (
+				AABB000100000001EEEEEE01 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+			);
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -473,6 +482,7 @@
 				FF00000100000001AAAAAA01 /* ReportService.swift in Sources */,
 				FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */,
 				FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */,
+				AB00000100000001AAAAAA01 /* SupabaseClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -644,6 +654,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "binthere needs camera access to scan QR codes and take photos of items.";
 				INFOPLIST_KEY_NFCReaderUsageDescription = "binthere scans NFC tags to identify bins and items.";
+				SUPABASE_URL = "$(SUPABASE_URL)";
+				SUPABASE_ANON_KEY = "$(SUPABASE_ANON_KEY)";
 				INFOPLIST_KEY_NSHomeKitUsageDescription = "binthere can import room names from HomeKit to use as zones.";
 				CODE_SIGN_ENTITLEMENTS = binthere/binthere.entitlements;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -676,6 +688,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "binthere needs camera access to scan QR codes and take photos of items.";
 				INFOPLIST_KEY_NFCReaderUsageDescription = "binthere scans NFC tags to identify bins and items.";
+				SUPABASE_URL = "$(SUPABASE_URL)";
+				SUPABASE_ANON_KEY = "$(SUPABASE_ANON_KEY)";
 				INFOPLIST_KEY_NSHomeKitUsageDescription = "binthere can import room names from HomeKit to use as zones.";
 				CODE_SIGN_ENTITLEMENTS = binthere/binthere.entitlements;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -804,6 +818,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		AABB000100000001EEEEEE01 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AABB000100000001DDDDDD01 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AABB000100000001EEEEEE01 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 2FBD3E182BEAC2D100B0C02C /* Project object */;
 }

--- a/binthere/Services/SupabaseClient.swift
+++ b/binthere/Services/SupabaseClient.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Supabase
+
+@Observable
+final class SupabaseManager {
+    static let shared = SupabaseManager()
+
+    let client: SupabaseClient
+
+    var isAuthenticated: Bool {
+        currentUserId != nil
+    }
+
+    var currentUserId: String?
+
+    private init() {
+        guard let urlString = Bundle.main.infoDictionary?["SUPABASE_URL"] as? String,
+              let url = URL(string: urlString),
+              let anonKey = Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String,
+              !urlString.contains("YOUR_PROJECT") else {
+            // Fallback for development without Supabase configured
+            client = SupabaseClient(
+                supabaseURL: URL(string: "https://placeholder.supabase.co")!,
+                supabaseKey: "placeholder"
+            )
+            return
+        }
+
+        client = SupabaseClient(supabaseURL: url, supabaseKey: anonKey)
+    }
+
+    func refreshAuthState() async {
+        do {
+            let session = try await client.auth.session
+            currentUserId = session.user.id.uuidString
+        } catch {
+            currentUserId = nil
+        }
+    }
+}

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,139 @@
+-- 001_initial_schema.sql
+-- binthere database schema with multi-user household support
+
+-- Households
+CREATE TABLE households (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    created_by UUID NOT NULL REFERENCES auth.users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Household members
+CREATE TABLE household_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id),
+    role TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('owner', 'admin', 'member')),
+    display_name TEXT NOT NULL DEFAULT '',
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (household_id, user_id)
+);
+
+-- Invitations
+CREATE TABLE invitations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    invited_by UUID NOT NULL REFERENCES auth.users(id),
+    invite_code TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'expired')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '7 days')
+);
+
+-- Zones
+CREATE TABLE zones (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    name TEXT NOT NULL DEFAULT '',
+    location_description TEXT NOT NULL DEFAULT '',
+    color TEXT NOT NULL DEFAULT '',
+    icon TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Bins
+CREATE TABLE bins (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    zone_id UUID REFERENCES zones(id) ON DELETE SET NULL,
+    code TEXT NOT NULL DEFAULT '',
+    name TEXT NOT NULL DEFAULT '',
+    bin_description TEXT NOT NULL DEFAULT '',
+    location TEXT NOT NULL DEFAULT '',
+    color TEXT NOT NULL DEFAULT '',
+    qr_code_image_path TEXT,
+    content_image_paths TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Items
+CREATE TABLE items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    bin_id UUID REFERENCES bins(id) ON DELETE CASCADE,
+    name TEXT NOT NULL DEFAULT '',
+    item_description TEXT NOT NULL DEFAULT '',
+    image_paths TEXT[] NOT NULL DEFAULT '{}',
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    color TEXT NOT NULL DEFAULT '',
+    notes TEXT NOT NULL DEFAULT '',
+    value DOUBLE PRECISION,
+    value_source TEXT NOT NULL DEFAULT '',
+    value_updated_at TIMESTAMPTZ,
+    is_checked_out BOOLEAN NOT NULL DEFAULT false,
+    created_by UUID REFERENCES auth.users(id),
+    checkout_permission TEXT NOT NULL DEFAULT 'anyone' CHECK (checkout_permission IN ('anyone', 'specific_users', 'none')),
+    allowed_checkout_users UUID[] NOT NULL DEFAULT '{}',
+    max_checkout_days INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Checkout records
+CREATE TABLE checkout_records (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    checked_out_by UUID REFERENCES auth.users(id),
+    checked_out_to TEXT NOT NULL DEFAULT '',
+    checked_out_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    checked_in_at TIMESTAMPTZ,
+    expected_return_date TIMESTAMPTZ,
+    notes TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Custom attributes
+CREATE TABLE custom_attributes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+    name TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL DEFAULT 'text',
+    text_value TEXT NOT NULL DEFAULT '',
+    number_value DOUBLE PRECISION,
+    date_value TIMESTAMPTZ,
+    bool_value BOOLEAN NOT NULL DEFAULT false,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX idx_household_members_user ON household_members(user_id);
+CREATE INDEX idx_household_members_household ON household_members(household_id);
+CREATE INDEX idx_invitations_code ON invitations(invite_code);
+CREATE INDEX idx_zones_household ON zones(household_id);
+CREATE INDEX idx_bins_household ON bins(household_id);
+CREATE INDEX idx_bins_zone ON bins(zone_id);
+CREATE INDEX idx_items_household ON items(household_id);
+CREATE INDEX idx_items_bin ON items(bin_id);
+CREATE INDEX idx_checkout_records_item ON checkout_records(item_id);
+CREATE INDEX idx_checkout_records_household ON checkout_records(household_id);
+CREATE INDEX idx_custom_attributes_item ON custom_attributes(item_id);
+
+-- Updated_at trigger function
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply updated_at triggers
+CREATE TRIGGER zones_updated_at BEFORE UPDATE ON zones FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+CREATE TRIGGER bins_updated_at BEFORE UPDATE ON bins FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+CREATE TRIGGER items_updated_at BEFORE UPDATE ON items FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/002_rls_policies.sql
+++ b/supabase/migrations/002_rls_policies.sql
@@ -1,0 +1,121 @@
+-- 002_rls_policies.sql
+-- Row Level Security: users can only access data within their household
+
+-- Enable RLS on all tables
+ALTER TABLE households ENABLE ROW LEVEL SECURITY;
+ALTER TABLE household_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE zones ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bins ENABLE ROW LEVEL SECURITY;
+ALTER TABLE items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE checkout_records ENABLE ROW LEVEL SECURITY;
+ALTER TABLE custom_attributes ENABLE ROW LEVEL SECURITY;
+
+-- Helper function: check if user belongs to a household
+CREATE OR REPLACE FUNCTION user_in_household(h_id UUID)
+RETURNS BOOLEAN AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM household_members
+        WHERE household_id = h_id AND user_id = auth.uid()
+    );
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Households: members can read, only creator can create
+CREATE POLICY "Members can view their households"
+    ON households FOR SELECT
+    USING (user_in_household(id));
+
+CREATE POLICY "Authenticated users can create households"
+    ON households FOR INSERT
+    WITH CHECK (auth.uid() = created_by);
+
+CREATE POLICY "Owners can update their households"
+    ON households FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM household_members
+            WHERE household_id = id AND user_id = auth.uid() AND role = 'owner'
+        )
+    );
+
+-- Household members: members can view, owner/admin can manage
+CREATE POLICY "Members can view household members"
+    ON household_members FOR SELECT
+    USING (user_in_household(household_id));
+
+CREATE POLICY "Can insert own membership"
+    ON household_members FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Owners can manage members"
+    ON household_members FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM household_members AS hm
+            WHERE hm.household_id = household_members.household_id
+            AND hm.user_id = auth.uid()
+            AND hm.role IN ('owner', 'admin')
+        )
+    );
+
+-- Invitations: household members can view, owner/admin can create
+CREATE POLICY "Members can view invitations"
+    ON invitations FOR SELECT
+    USING (user_in_household(household_id));
+
+CREATE POLICY "Admin+ can create invitations"
+    ON invitations FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM household_members
+            WHERE household_id = invitations.household_id
+            AND user_id = auth.uid()
+            AND role IN ('owner', 'admin')
+        )
+    );
+
+-- Anyone can read invitations by code (for joining)
+CREATE POLICY "Anyone can look up pending invitations by code"
+    ON invitations FOR SELECT
+    USING (status = 'pending');
+
+CREATE POLICY "Invitees can accept invitations"
+    ON invitations FOR UPDATE
+    USING (status = 'pending')
+    WITH CHECK (status = 'accepted');
+
+-- Zones, Bins, Items, Checkout Records, Custom Attributes:
+-- All follow the same pattern: household members can CRUD
+
+-- Zones
+CREATE POLICY "Members can view zones" ON zones FOR SELECT USING (user_in_household(household_id));
+CREATE POLICY "Members can create zones" ON zones FOR INSERT WITH CHECK (user_in_household(household_id));
+CREATE POLICY "Members can update zones" ON zones FOR UPDATE USING (user_in_household(household_id));
+CREATE POLICY "Members can delete zones" ON zones FOR DELETE USING (user_in_household(household_id));
+
+-- Bins
+CREATE POLICY "Members can view bins" ON bins FOR SELECT USING (user_in_household(household_id));
+CREATE POLICY "Members can create bins" ON bins FOR INSERT WITH CHECK (user_in_household(household_id));
+CREATE POLICY "Members can update bins" ON bins FOR UPDATE USING (user_in_household(household_id));
+CREATE POLICY "Members can delete bins" ON bins FOR DELETE USING (user_in_household(household_id));
+
+-- Items
+CREATE POLICY "Members can view items" ON items FOR SELECT USING (user_in_household(household_id));
+CREATE POLICY "Members can create items" ON items FOR INSERT WITH CHECK (user_in_household(household_id));
+CREATE POLICY "Members can update items" ON items FOR UPDATE USING (user_in_household(household_id));
+CREATE POLICY "Members can delete items" ON items FOR DELETE USING (user_in_household(household_id));
+
+-- Checkout records
+CREATE POLICY "Members can view checkouts" ON checkout_records FOR SELECT USING (user_in_household(household_id));
+CREATE POLICY "Members can create checkouts" ON checkout_records FOR INSERT WITH CHECK (user_in_household(household_id));
+CREATE POLICY "Members can update checkouts" ON checkout_records FOR UPDATE USING (user_in_household(household_id));
+
+-- Custom attributes
+CREATE POLICY "Members can view attributes" ON custom_attributes FOR SELECT USING (user_in_household(household_id));
+CREATE POLICY "Members can create attributes" ON custom_attributes FOR INSERT WITH CHECK (user_in_household(household_id));
+CREATE POLICY "Members can update attributes" ON custom_attributes FOR UPDATE USING (user_in_household(household_id));
+CREATE POLICY "Members can delete attributes" ON custom_attributes FOR DELETE USING (user_in_household(household_id));
+
+-- Storage bucket for images (create via Supabase dashboard)
+-- Bucket name: 'item-images'
+-- Policy: authenticated users can upload/read within their household path


### PR DESCRIPTION
## Summary

Phase 7, PR A — foundation for multi-user backend.

- **supabase-swift v2.x** added as SPM dependency
- **SupabaseManager** singleton: reads project URL + anon key from `Secrets.xcconfig` via Info.plist build settings. Falls back gracefully if not configured.
- **Database migrations**: full schema mirroring SwiftData models with multi-user support — households, members, invitations, zones, bins, items, checkout records, custom attributes. Includes checkout permissions, allowed users, max checkout days.
- **RLS policies**: all tables enforce household isolation via `user_in_household()` helper. Members can CRUD within their household, owners/admins manage members and invitations.
- **Secrets.xcconfig.example**: template for Supabase credentials (real file is git-ignored)

### Setup required
1. Copy `Secrets.xcconfig.example` to `Secrets.xcconfig`
2. Fill in your Supabase project URL and anon key
3. Run the SQL migrations in your Supabase dashboard (SQL Editor)

## Test plan

- [ ] Build succeeds with Supabase package resolved
- [ ] App launches without Supabase configured (graceful fallback)
- [ ] Run migrations in Supabase SQL Editor → verify tables created
- [ ] Verify RLS policies active on all tables
- [ ] Run unit tests (existing tests unaffected)