### PR TITLE
feat: sync service with bidirectional Supabase sync

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		AB00000100000003AAAAAA01 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000003BBBBBB01 /* SignInView.swift */; };
 		AB00000100000004AAAAAA01 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000004BBBBBB01 /* SignUpView.swift */; };
 		AB00000100000005AAAAAA01 /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000005BBBBBB01 /* AuthGateView.swift */; };
+		AB00000100000007AAAAAA01 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000007BBBBBB01 /* SyncService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 		AB00000100000003BBBBBB01 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		AB00000100000004BBBBBB01 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		AB00000100000005BBBBBB01 /* AuthGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthGateView.swift; sourceTree = "<group>"; };
+		AB00000100000007BBBBBB01 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -249,6 +251,7 @@
 				FF00000100000001BBBBBB01 /* ReportService.swift */,
 				AB00000100000001BBBBBB01 /* SupabaseClient.swift */,
 				AB00000100000002BBBBBB01 /* AuthService.swift */,
+				AB00000100000007BBBBBB01 /* SyncService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -507,6 +510,7 @@
 				AB00000100000003AAAAAA01 /* SignInView.swift in Sources */,
 				AB00000100000004AAAAAA01 /* SignUpView.swift in Sources */,
 				AB00000100000005AAAAAA01 /* AuthGateView.swift in Sources */,
+				AB00000100000007AAAAAA01 /* SyncService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/binthere/Item.swift
+++ b/binthere/Item.swift
@@ -4,6 +4,7 @@ import SwiftData
 @Model
 final class Item {
     var id: UUID = UUID()
+    var householdId: String = ""
     var name: String = ""
     var itemDescription: String = ""
     var imagePaths: [String] = []
@@ -11,11 +12,16 @@ final class Item {
     var customFields: [String: String] = [:]
     var color: String = ""
     var createdAt: Date = Date()
+    var updatedAt: Date = Date()
     var isCheckedOut: Bool = false
     var notes: String = ""
     var value: Double?
     var valueSource: String = ""
     var valueUpdatedAt: Date?
+    var createdBy: String = ""
+    var checkoutPermission: String = "anyone"
+    var allowedCheckoutUsers: [String] = []
+    var maxCheckoutDays: Int?
 
     var bin: Bin?
 

--- a/binthere/Models/Bin.swift
+++ b/binthere/Models/Bin.swift
@@ -4,12 +4,14 @@ import SwiftData
 @Model
 final class Bin {
     var id: UUID = UUID()
+    var householdId: String = ""
     var code: String = ""
     var name: String = ""
     var binDescription: String = ""
     var location: String = ""
     var color: String = ""
     var createdAt: Date = Date()
+    var updatedAt: Date = Date()
     var qrCodeImagePath: String?
     var contentImagePaths: [String] = []
 

--- a/binthere/Models/CheckoutRecord.swift
+++ b/binthere/Models/CheckoutRecord.swift
@@ -4,9 +4,11 @@ import SwiftData
 @Model
 final class CheckoutRecord {
     var id: UUID = UUID()
+    var householdId: String = ""
     var checkedOutAt: Date = Date()
     var checkedInAt: Date?
     var checkedOutTo: String = ""
+    var checkedOutBy: String = ""
     var notes: String = ""
     var expectedReturnDate: Date?
 
@@ -19,6 +21,15 @@ final class CheckoutRecord {
     init(item: Item, checkedOutTo: String, expectedReturnDate: Date? = nil, notes: String = "") {
         self.id = UUID()
         self.item = item
+        self.checkedOutTo = checkedOutTo
+        self.checkedOutAt = Date()
+        self.expectedReturnDate = expectedReturnDate
+        self.notes = notes
+    }
+
+    /// Init for sync — item is set separately after fetching from local store
+    init(checkedOutTo: String, expectedReturnDate: Date? = nil, notes: String = "") {
+        self.id = UUID()
         self.checkedOutTo = checkedOutTo
         self.checkedOutAt = Date()
         self.expectedReturnDate = expectedReturnDate

--- a/binthere/Models/CustomAttribute.swift
+++ b/binthere/Models/CustomAttribute.swift
@@ -34,6 +34,7 @@ enum AttributeType: String, CaseIterable, Identifiable {
 @Model
 final class CustomAttribute {
     var id: UUID = UUID()
+    var householdId: String = ""
     var name: String = ""
     var type: String = AttributeType.text.rawValue
     var textValue: String = ""

--- a/binthere/Models/Zone.swift
+++ b/binthere/Models/Zone.swift
@@ -4,10 +4,12 @@ import SwiftData
 @Model
 final class Zone {
     var id: UUID = UUID()
+    var householdId: String = ""
     var name: String = ""
     var locationDescription: String = ""
     var color: String = ""
     var icon: String = ""
+    var updatedAt: Date = Date()
 
     @Relationship(deleteRule: .nullify, inverse: \Bin.zone)
     var bins: [Bin] = []

--- a/binthere/Services/SyncService.swift
+++ b/binthere/Services/SyncService.swift
@@ -1,0 +1,437 @@
+import Foundation
+import SwiftData
+import Supabase
+
+@Observable
+final class SyncService {
+    var isSyncing = false
+    var lastSyncedAt: Date?
+    var error: String?
+
+    private var client: SupabaseClient { SupabaseManager.shared.client }
+    private var modelContext: ModelContext?
+
+    func configure(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Full Sync
+
+    func syncAll(householdId: String) async {
+        guard !isSyncing else { return }
+        isSyncing = true
+        error = nil
+        defer { isSyncing = false }
+
+        do {
+            try await pullZones(householdId: householdId)
+            try await pullBins(householdId: householdId)
+            try await pullItems(householdId: householdId)
+            try await pullCheckoutRecords(householdId: householdId)
+            try await pullCustomAttributes(householdId: householdId)
+            lastSyncedAt = Date()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Push Individual Records
+
+    func pushZone(_ zone: Zone, householdId: String) async throws {
+        let payload: [String: AnyJSON] = [
+            "id": .string(zone.id.uuidString),
+            "household_id": .string(householdId),
+            "name": .string(zone.name),
+            "location_description": .string(zone.locationDescription),
+            "color": .string(zone.color),
+            "icon": .string(zone.icon),
+        ]
+        try await client.from("zones").upsert(payload).execute()
+        zone.updatedAt = Date()
+    }
+
+    func pushBin(_ bin: Bin, householdId: String) async throws {
+        var payload: [String: AnyJSON] = [
+            "id": .string(bin.id.uuidString),
+            "household_id": .string(householdId),
+            "code": .string(bin.code),
+            "name": .string(bin.name),
+            "bin_description": .string(bin.binDescription),
+            "location": .string(bin.location),
+            "color": .string(bin.color),
+        ]
+        if let zoneId = bin.zone?.id {
+            payload["zone_id"] = .string(zoneId.uuidString)
+        }
+        try await client.from("bins").upsert(payload).execute()
+        bin.updatedAt = Date()
+    }
+
+    func pushItem(_ item: Item, householdId: String) async throws {
+        var payload: [String: AnyJSON] = [
+            "id": .string(item.id.uuidString),
+            "household_id": .string(householdId),
+            "name": .string(item.name),
+            "item_description": .string(item.itemDescription),
+            "color": .string(item.color),
+            "notes": .string(item.notes),
+            "is_checked_out": .bool(item.isCheckedOut),
+            "value_source": .string(item.valueSource),
+            "created_by": .string(item.createdBy),
+            "checkout_permission": .string(item.checkoutPermission),
+            "tags": .array(item.tags.map { .string($0) }),
+            "image_paths": .array(item.imagePaths.map { .string($0) }),
+            "allowed_checkout_users": .array(item.allowedCheckoutUsers.map { .string($0) }),
+        ]
+        if let binId = item.bin?.id {
+            payload["bin_id"] = .string(binId.uuidString)
+        }
+        if let value = item.value {
+            payload["value"] = .double(value)
+        }
+        if let maxDays = item.maxCheckoutDays {
+            payload["max_checkout_days"] = .integer(maxDays)
+        }
+        try await client.from("items").upsert(payload).execute()
+        item.updatedAt = Date()
+    }
+
+    func pushCheckoutRecord(_ record: CheckoutRecord, householdId: String) async throws {
+        var payload: [String: AnyJSON] = [
+            "id": .string(record.id.uuidString),
+            "household_id": .string(householdId),
+            "checked_out_to": .string(record.checkedOutTo),
+            "checked_out_by": .string(record.checkedOutBy),
+            "notes": .string(record.notes),
+        ]
+        if let itemId = record.item?.id {
+            payload["item_id"] = .string(itemId.uuidString)
+        }
+        if let checkedInAt = record.checkedInAt {
+            payload["checked_in_at"] = .string(ISO8601DateFormatter().string(from: checkedInAt))
+        }
+        if let returnDate = record.expectedReturnDate {
+            payload["expected_return_date"] = .string(ISO8601DateFormatter().string(from: returnDate))
+        }
+        try await client.from("checkout_records").upsert(payload).execute()
+    }
+
+    // MARK: - Pull from Supabase
+
+    private func pullZones(householdId: String) async throws {
+        guard let context = modelContext else { return }
+
+        let response: [RemoteZone] = try await client.from("zones")
+            .select()
+            .eq("household_id", value: householdId)
+            .execute()
+            .value
+
+        for remote in response {
+            let remoteId = remote.id
+            let descriptor = FetchDescriptor<Zone>(predicate: #Predicate { $0.id == remoteId })
+            if let existing = try context.fetch(descriptor).first {
+                if remote.updatedAt > existing.updatedAt {
+                    existing.name = remote.name
+                    existing.locationDescription = remote.locationDescription
+                    existing.color = remote.color
+                    existing.icon = remote.icon
+                    existing.updatedAt = remote.updatedAt
+                }
+            } else {
+                let zone = Zone(name: remote.name, locationDescription: remote.locationDescription,
+                                color: remote.color, icon: remote.icon)
+                zone.id = remote.id
+                zone.householdId = householdId
+                zone.updatedAt = remote.updatedAt
+                context.insert(zone)
+            }
+        }
+        try context.save()
+    }
+
+    private func pullBins(householdId: String) async throws {
+        guard let context = modelContext else { return }
+
+        let response: [RemoteBin] = try await client.from("bins")
+            .select()
+            .eq("household_id", value: householdId)
+            .execute()
+            .value
+
+        for remote in response {
+            let remoteId = remote.id
+            let descriptor = FetchDescriptor<Bin>(predicate: #Predicate { $0.id == remoteId })
+            if let existing = try context.fetch(descriptor).first {
+                if remote.updatedAt > existing.updatedAt {
+                    existing.code = remote.code
+                    existing.name = remote.name
+                    existing.binDescription = remote.binDescription
+                    existing.location = remote.location
+                    existing.color = remote.color
+                    existing.updatedAt = remote.updatedAt
+                }
+            } else {
+                let bin = Bin(code: remote.code, name: remote.name,
+                              binDescription: remote.binDescription, location: remote.location)
+                bin.id = remote.id
+                bin.householdId = householdId
+                bin.color = remote.color
+                bin.updatedAt = remote.updatedAt
+
+                // Link to zone
+                if let zoneId = remote.zoneId {
+                    let zoneDescriptor = FetchDescriptor<Zone>(predicate: #Predicate { $0.id == zoneId })
+                    bin.zone = try context.fetch(zoneDescriptor).first
+                }
+
+                context.insert(bin)
+            }
+        }
+        try context.save()
+    }
+
+    private func pullItems(householdId: String) async throws {
+        guard let context = modelContext else { return }
+
+        let response: [RemoteItem] = try await client.from("items")
+            .select()
+            .eq("household_id", value: householdId)
+            .execute()
+            .value
+
+        for remote in response {
+            let remoteId = remote.id
+            let descriptor = FetchDescriptor<Item>(predicate: #Predicate { $0.id == remoteId })
+            if let existing = try context.fetch(descriptor).first {
+                if remote.updatedAt > existing.updatedAt {
+                    existing.name = remote.name
+                    existing.itemDescription = remote.itemDescription
+                    existing.color = remote.color
+                    existing.notes = remote.notes
+                    existing.isCheckedOut = remote.isCheckedOut
+                    existing.value = remote.value
+                    existing.valueSource = remote.valueSource
+                    existing.tags = remote.tags
+                    existing.checkoutPermission = remote.checkoutPermission
+                    existing.allowedCheckoutUsers = remote.allowedCheckoutUsers
+                    existing.maxCheckoutDays = remote.maxCheckoutDays
+                    existing.updatedAt = remote.updatedAt
+                }
+            } else {
+                let item = Item(name: remote.name, itemDescription: remote.itemDescription)
+                item.id = remote.id
+                item.householdId = householdId
+                item.color = remote.color
+                item.notes = remote.notes
+                item.isCheckedOut = remote.isCheckedOut
+                item.value = remote.value
+                item.valueSource = remote.valueSource
+                item.tags = remote.tags
+                item.createdBy = remote.createdBy
+                item.checkoutPermission = remote.checkoutPermission
+                item.allowedCheckoutUsers = remote.allowedCheckoutUsers
+                item.maxCheckoutDays = remote.maxCheckoutDays
+                item.updatedAt = remote.updatedAt
+
+                if let binId = remote.binId {
+                    let binDescriptor = FetchDescriptor<Bin>(predicate: #Predicate { $0.id == binId })
+                    item.bin = try context.fetch(binDescriptor).first
+                }
+
+                context.insert(item)
+            }
+        }
+        try context.save()
+    }
+
+    private func pullCheckoutRecords(householdId: String) async throws {
+        guard let context = modelContext else { return }
+
+        let response: [RemoteCheckoutRecord] = try await client.from("checkout_records")
+            .select()
+            .eq("household_id", value: householdId)
+            .execute()
+            .value
+
+        for remote in response {
+            let remoteId = remote.id
+            let descriptor = FetchDescriptor<CheckoutRecord>(predicate: #Predicate { $0.id == remoteId })
+            if try context.fetch(descriptor).first == nil {
+                let record = CheckoutRecord(
+                    checkedOutTo: remote.checkedOutTo,
+                    expectedReturnDate: remote.expectedReturnDate,
+                    notes: remote.notes
+                )
+                record.id = remote.id
+                record.householdId = householdId
+                record.checkedOutBy = remote.checkedOutBy
+                record.checkedOutAt = remote.checkedOutAt
+                record.checkedInAt = remote.checkedInAt
+
+                let remoteItemId = remote.itemId
+                let itemDescriptor = FetchDescriptor<Item>(predicate: #Predicate { $0.id == remoteItemId })
+                record.item = try context.fetch(itemDescriptor).first
+
+                context.insert(record)
+            }
+        }
+        try context.save()
+    }
+
+    private func pullCustomAttributes(householdId: String) async throws {
+        guard let context = modelContext else { return }
+
+        let response: [RemoteCustomAttribute] = try await client.from("custom_attributes")
+            .select()
+            .eq("household_id", value: householdId)
+            .execute()
+            .value
+
+        for remote in response {
+            let remoteId = remote.id
+            let descriptor = FetchDescriptor<CustomAttribute>(predicate: #Predicate { $0.id == remoteId })
+            if try context.fetch(descriptor).first == nil {
+                let attr = CustomAttribute(name: remote.name,
+                                           type: AttributeType(rawValue: remote.type) ?? .text,
+                                           sortOrder: remote.sortOrder)
+                attr.id = remote.id
+                attr.householdId = householdId
+                attr.textValue = remote.textValue
+                attr.numberValue = remote.numberValue
+                attr.dateValue = remote.dateValue
+                attr.boolValue = remote.boolValue
+
+                let remoteItemId = remote.itemId
+                let itemDescriptor = FetchDescriptor<Item>(predicate: #Predicate { $0.id == remoteItemId })
+                attr.item = try context.fetch(itemDescriptor).first
+
+                context.insert(attr)
+            }
+        }
+        try context.save()
+    }
+
+    // MARK: - Delete
+
+    func deleteRemoteZone(_ id: UUID) async throws {
+        try await client.from("zones").delete().eq("id", value: id.uuidString).execute()
+    }
+
+    func deleteRemoteBin(_ id: UUID) async throws {
+        try await client.from("bins").delete().eq("id", value: id.uuidString).execute()
+    }
+
+    func deleteRemoteItem(_ id: UUID) async throws {
+        try await client.from("items").delete().eq("id", value: id.uuidString).execute()
+    }
+}
+
+// MARK: - Remote DTOs (Decodable structs for Supabase responses)
+
+private struct RemoteZone: Decodable {
+    let id: UUID
+    let name: String
+    let locationDescription: String
+    let color: String
+    let icon: String
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, color, icon
+        case locationDescription = "location_description"
+        case updatedAt = "updated_at"
+    }
+}
+
+private struct RemoteBin: Decodable {
+    let id: UUID
+    let code: String
+    let name: String
+    let binDescription: String
+    let location: String
+    let color: String
+    let zoneId: UUID?
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, code, name, location, color
+        case binDescription = "bin_description"
+        case zoneId = "zone_id"
+        case updatedAt = "updated_at"
+    }
+}
+
+private struct RemoteItem: Decodable {
+    let id: UUID
+    let name: String
+    let itemDescription: String
+    let color: String
+    let notes: String
+    let isCheckedOut: Bool
+    let value: Double?
+    let valueSource: String
+    let tags: [String]
+    let binId: UUID?
+    let createdBy: String
+    let checkoutPermission: String
+    let allowedCheckoutUsers: [String]
+    let maxCheckoutDays: Int?
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, color, notes, value, tags
+        case itemDescription = "item_description"
+        case isCheckedOut = "is_checked_out"
+        case valueSource = "value_source"
+        case binId = "bin_id"
+        case createdBy = "created_by"
+        case checkoutPermission = "checkout_permission"
+        case allowedCheckoutUsers = "allowed_checkout_users"
+        case maxCheckoutDays = "max_checkout_days"
+        case updatedAt = "updated_at"
+    }
+}
+
+private struct RemoteCheckoutRecord: Decodable {
+    let id: UUID
+    let itemId: UUID
+    let checkedOutTo: String
+    let checkedOutBy: String
+    let checkedOutAt: Date
+    let checkedInAt: Date?
+    let expectedReturnDate: Date?
+    let notes: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, notes
+        case itemId = "item_id"
+        case checkedOutTo = "checked_out_to"
+        case checkedOutBy = "checked_out_by"
+        case checkedOutAt = "checked_out_at"
+        case checkedInAt = "checked_in_at"
+        case expectedReturnDate = "expected_return_date"
+    }
+}
+
+private struct RemoteCustomAttribute: Decodable {
+    let id: UUID
+    let itemId: UUID
+    let name: String
+    let type: String
+    let textValue: String
+    let numberValue: Double?
+    let dateValue: Date?
+    let boolValue: Bool
+    let sortOrder: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, type
+        case itemId = "item_id"
+        case textValue = "text_value"
+        case numberValue = "number_value"
+        case dateValue = "date_value"
+        case boolValue = "bool_value"
+        case sortOrder = "sort_order"
+    }
+}

--- a/binthere/Views/Auth/AuthGateView.swift
+++ b/binthere/Views/Auth/AuthGateView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
+import SwiftData
 
 struct AuthGateView: View {
+    @Environment(\.modelContext) private var modelContext
     @State private var authService = AuthService()
+    @State private var syncService = SyncService()
     @State private var hasCheckedSession = false
 
     var body: some View {
@@ -15,9 +18,20 @@ struct AuthGateView: View {
             }
         }
         .environment(authService)
+        .environment(syncService)
         .task {
             await authService.restoreSession()
             hasCheckedSession = true
+            syncService.configure(modelContext: modelContext)
+        }
+        .onChange(of: authService.isAuthenticated) { _, isAuth in
+            if isAuth {
+                // Sync on sign-in — for now uses empty householdId
+                // Will be populated by HouseholdService in PR D
+                Task {
+                    await syncService.syncAll(householdId: "")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 7, PR C — data sync between SwiftData and Supabase.

**Model updates:**
- All models get `householdId` for multi-tenant isolation
- Zone, Bin, Item get `updatedAt` for last-write-wins conflict resolution
- Item gets `createdBy`, `checkoutPermission`, `allowedCheckoutUsers`, `maxCheckoutDays` (used in PR E)
- CheckoutRecord gets `checkedOutBy` (user ID) and a sync-friendly init

**SyncService:**
- `syncAll(householdId:)` — pulls all data from Supabase into SwiftData
- `pushZone/Bin/Item/CheckoutRecord` — upserts individual records to Supabase
- `deleteRemoteZone/Bin/Item` — removes from Supabase by ID
- Last-write-wins conflict resolution using `updatedAt` timestamps
- Remote DTOs with snake_case CodingKeys for Supabase column mapping
- All operations async and household-scoped

**AuthGateView:** injects SyncService into environment, triggers sync on sign-in.

## Test plan

- [ ] Build succeeds with all model changes
- [ ] Sign in → verify sync triggers (check Supabase logs)
- [ ] Create a zone locally → call pushZone → verify row in Supabase
- [ ] Add row in Supabase SQL Editor → sync → verify it appears locally
- [ ] Modify same record locally and remotely → sync → last-write wins
- [ ] Lint passes