### PR TITLE
feat: household management — create, invite, join, members

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -53,6 +53,11 @@
 		AB00000100000004AAAAAA01 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000004BBBBBB01 /* SignUpView.swift */; };
 		AB00000100000005AAAAAA01 /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000005BBBBBB01 /* AuthGateView.swift */; };
 		AB00000100000007AAAAAA01 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000007BBBBBB01 /* SyncService.swift */; };
+		AB00000100000008AAAAAA01 /* HouseholdService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000008BBBBBB01 /* HouseholdService.swift */; };
+		AB00000100000009AAAAAA01 /* HouseholdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000009BBBBBB01 /* HouseholdView.swift */; };
+		AB0000010000000AAAAAAA01 /* InviteMemberSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000ABBBBBB01 /* InviteMemberSheet.swift */; };
+		AB0000010000000BAAAAAA01 /* JoinHouseholdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000BBBBBBB01 /* JoinHouseholdView.swift */; };
+		AB0000010000000CAAAAAA01 /* HouseholdSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000CBBBBBB01 /* HouseholdSetupView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +128,11 @@
 		AB00000100000004BBBBBB01 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		AB00000100000005BBBBBB01 /* AuthGateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthGateView.swift; sourceTree = "<group>"; };
 		AB00000100000007BBBBBB01 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
+		AB00000100000008BBBBBB01 /* HouseholdService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseholdService.swift; sourceTree = "<group>"; };
+		AB00000100000009BBBBBB01 /* HouseholdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseholdView.swift; sourceTree = "<group>"; };
+		AB0000010000000ABBBBBB01 /* InviteMemberSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMemberSheet.swift; sourceTree = "<group>"; };
+		AB0000010000000BBBBBBB01 /* JoinHouseholdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinHouseholdView.swift; sourceTree = "<group>"; };
+		AB0000010000000CBBBBBB01 /* HouseholdSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseholdSetupView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,6 +240,7 @@
 			children = (
 				AA00000100000005BBBBBB01 /* MainTabView.swift */,
 				AB00000100000006CCCCCC01 /* Auth */,
+				AB0000010000000DCCCCCC01 /* Household */,
 				AA00000100000023CCCCCC01 /* Bins */,
 				AA00000100000024CCCCCC01 /* Items */,
 				CC00000100000005CCCCCC01 /* Zones */,
@@ -252,6 +263,7 @@
 				AB00000100000001BBBBBB01 /* SupabaseClient.swift */,
 				AB00000100000002BBBBBB01 /* AuthService.swift */,
 				AB00000100000007BBBBBB01 /* SyncService.swift */,
+				AB00000100000008BBBBBB01 /* HouseholdService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -305,6 +317,17 @@
 				EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		AB0000010000000DCCCCCC01 /* Household */ = {
+			isa = PBXGroup;
+			children = (
+				AB00000100000009BBBBBB01 /* HouseholdView.swift */,
+				AB0000010000000ABBBBBB01 /* InviteMemberSheet.swift */,
+				AB0000010000000BBBBBBB01 /* JoinHouseholdView.swift */,
+				AB0000010000000CBBBBBB01 /* HouseholdSetupView.swift */,
+			);
+			path = Household;
 			sourceTree = "<group>";
 		};
 		AB00000100000006CCCCCC01 /* Auth */ = {
@@ -511,6 +534,11 @@
 				AB00000100000004AAAAAA01 /* SignUpView.swift in Sources */,
 				AB00000100000005AAAAAA01 /* AuthGateView.swift in Sources */,
 				AB00000100000007AAAAAA01 /* SyncService.swift in Sources */,
+				AB00000100000008AAAAAA01 /* HouseholdService.swift in Sources */,
+				AB00000100000009AAAAAA01 /* HouseholdView.swift in Sources */,
+				AB0000010000000AAAAAAA01 /* InviteMemberSheet.swift in Sources */,
+				AB0000010000000BAAAAAA01 /* JoinHouseholdView.swift in Sources */,
+				AB0000010000000CAAAAAA01 /* HouseholdSetupView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/binthere/Services/HouseholdService.swift
+++ b/binthere/Services/HouseholdService.swift
@@ -1,0 +1,257 @@
+import Foundation
+import Supabase
+
+struct Household: Codable, Identifiable {
+    let id: UUID
+    let name: String
+    let createdBy: UUID
+    let createdAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case createdBy = "created_by"
+        case createdAt = "created_at"
+    }
+}
+
+struct HouseholdMember: Codable, Identifiable {
+    let id: UUID
+    let householdId: UUID
+    let userId: UUID
+    let role: String
+    let displayName: String
+    let joinedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, role
+        case householdId = "household_id"
+        case userId = "user_id"
+        case displayName = "display_name"
+        case joinedAt = "joined_at"
+    }
+}
+
+struct Invitation: Codable, Identifiable {
+    let id: UUID
+    let householdId: UUID
+    let inviteCode: String
+    let status: String
+    let createdAt: Date
+    let expiresAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, status
+        case householdId = "household_id"
+        case inviteCode = "invite_code"
+        case createdAt = "created_at"
+        case expiresAt = "expires_at"
+    }
+}
+
+@Observable
+final class HouseholdService {
+    var currentHousehold: Household?
+    var members: [HouseholdMember] = []
+    var pendingInvitations: [Invitation] = []
+    var isLoading = false
+    var error: String?
+
+    private var client: SupabaseClient { SupabaseManager.shared.client }
+
+    var currentHouseholdId: String {
+        currentHousehold?.id.uuidString ?? ""
+    }
+
+    // MARK: - Load Current Household
+
+    func loadHousehold(userId: String) async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            // Find household membership for this user
+            let memberships: [HouseholdMember] = try await client.from("household_members")
+                .select()
+                .eq("user_id", value: userId)
+                .execute()
+                .value
+
+            guard let membership = memberships.first else {
+                // No household yet — user needs to create or join one
+                currentHousehold = nil
+                return
+            }
+
+            // Fetch the household
+            let households: [Household] = try await client.from("households")
+                .select()
+                .eq("id", value: membership.householdId.uuidString)
+                .execute()
+                .value
+
+            currentHousehold = households.first
+            await loadMembers()
+            await loadInvitations()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Create Household
+
+    func createHousehold(name: String, userId: String, displayName: String) async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let householdId = UUID()
+
+            // Create household
+            let householdPayload: [String: AnyJSON] = [
+                "id": .string(householdId.uuidString),
+                "name": .string(name),
+                "created_by": .string(userId),
+            ]
+            try await client.from("households").insert(householdPayload).execute()
+
+            // Add creator as owner
+            let memberPayload: [String: AnyJSON] = [
+                "household_id": .string(householdId.uuidString),
+                "user_id": .string(userId),
+                "role": .string("owner"),
+                "display_name": .string(displayName),
+            ]
+            try await client.from("household_members").insert(memberPayload).execute()
+
+            // Reload
+            await loadHousehold(userId: userId)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Members
+
+    func loadMembers() async {
+        guard let householdId = currentHousehold?.id.uuidString else { return }
+
+        do {
+            members = try await client.from("household_members")
+                .select()
+                .eq("household_id", value: householdId)
+                .execute()
+                .value
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func updateMemberRole(memberId: UUID, role: String) async {
+        do {
+            try await client.from("household_members")
+                .update(["role": role])
+                .eq("id", value: memberId.uuidString)
+                .execute()
+            await loadMembers()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func removeMember(memberId: UUID) async {
+        do {
+            try await client.from("household_members")
+                .delete()
+                .eq("id", value: memberId.uuidString)
+                .execute()
+            await loadMembers()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Invitations
+
+    func loadInvitations() async {
+        guard let householdId = currentHousehold?.id.uuidString else { return }
+
+        do {
+            pendingInvitations = try await client.from("invitations")
+                .select()
+                .eq("household_id", value: householdId)
+                .eq("status", value: "pending")
+                .execute()
+                .value
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func generateInviteCode() async -> String? {
+        guard let householdId = currentHousehold?.id.uuidString,
+              let userId = try? await client.auth.session.user.id.uuidString else {
+            return nil
+        }
+
+        let code = CodeGenerator.generateCode(existingCodes: Set(pendingInvitations.map(\.inviteCode)))
+
+        do {
+            let payload: [String: AnyJSON] = [
+                "household_id": .string(householdId),
+                "invited_by": .string(userId),
+                "invite_code": .string(code),
+            ]
+            try await client.from("invitations").insert(payload).execute()
+            await loadInvitations()
+            return code
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
+
+    func joinHousehold(inviteCode: String, userId: String, displayName: String) async -> Bool {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            // Look up the invitation
+            let invitations: [Invitation] = try await client.from("invitations")
+                .select()
+                .eq("invite_code", value: inviteCode.uppercased())
+                .eq("status", value: "pending")
+                .execute()
+                .value
+
+            guard let invitation = invitations.first else {
+                error = "Invalid or expired invite code."
+                return false
+            }
+
+            // Add user as member
+            let memberPayload: [String: AnyJSON] = [
+                "household_id": .string(invitation.householdId.uuidString),
+                "user_id": .string(userId),
+                "role": .string("member"),
+                "display_name": .string(displayName),
+            ]
+            try await client.from("household_members").insert(memberPayload).execute()
+
+            // Mark invitation as accepted
+            try await client.from("invitations")
+                .update(["status": "accepted"])
+                .eq("id", value: invitation.id.uuidString)
+                .execute()
+
+            // Reload
+            await loadHousehold(userId: userId)
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+}

--- a/binthere/Views/Auth/AuthGateView.swift
+++ b/binthere/Views/Auth/AuthGateView.swift
@@ -5,31 +5,46 @@ struct AuthGateView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var authService = AuthService()
     @State private var syncService = SyncService()
+    @State private var householdService = HouseholdService()
     @State private var hasCheckedSession = false
 
     var body: some View {
         Group {
             if !hasCheckedSession {
                 ProgressView("Loading...")
-            } else if authService.isAuthenticated {
-                MainTabView()
-            } else {
+            } else if !authService.isAuthenticated {
                 SignInView()
+            } else if householdService.currentHousehold == nil && !householdService.isLoading {
+                HouseholdSetupView()
+            } else {
+                MainTabView()
             }
         }
         .environment(authService)
         .environment(syncService)
+        .environment(householdService)
         .task {
             await authService.restoreSession()
-            hasCheckedSession = true
             syncService.configure(modelContext: modelContext)
+            hasCheckedSession = true
+            if let userId = authService.currentUserId {
+                await householdService.loadHousehold(userId: userId)
+                if !householdService.currentHouseholdId.isEmpty {
+                    await syncService.syncAll(householdId: householdService.currentHouseholdId)
+                }
+            }
         }
         .onChange(of: authService.isAuthenticated) { _, isAuth in
-            if isAuth {
-                // Sync on sign-in — for now uses empty householdId
-                // Will be populated by HouseholdService in PR D
+            if isAuth, let userId = authService.currentUserId {
                 Task {
-                    await syncService.syncAll(householdId: "")
+                    await householdService.loadHousehold(userId: userId)
+                }
+            }
+        }
+        .onChange(of: householdService.currentHouseholdId) { _, newId in
+            if !newId.isEmpty {
+                Task {
+                    await syncService.syncAll(householdId: newId)
                 }
             }
         }

--- a/binthere/Views/Household/HouseholdSetupView.swift
+++ b/binthere/Views/Household/HouseholdSetupView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct HouseholdSetupView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(HouseholdService.self) private var householdService
+
+    @State private var householdName = ""
+    @State private var displayName = ""
+    @State private var showingJoin = false
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+
+            Image(systemName: "house")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue.opacity(0.6))
+
+            Text("Set Up Your Household")
+                .font(.title2.weight(.bold))
+
+            Text("Create a household to start organizing your bins, or join an existing one with an invite code.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            VStack(spacing: 12) {
+                TextField("Household Name (e.g. The Bennetts)", text: $householdName)
+                    .padding()
+                    .background(.quaternary)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                TextField("Your Name", text: $displayName)
+                    .textContentType(.name)
+                    .padding()
+                    .background(.quaternary)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                Button(action: createHousehold) {
+                    if householdService.isLoading {
+                        ProgressView()
+                            .frame(maxWidth: .infinity, minHeight: 20)
+                    } else {
+                        Text("Create Household")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity, minHeight: 20)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(householdName.isEmpty || displayName.isEmpty || householdService.isLoading)
+            }
+            .padding(.horizontal, 40)
+
+            HStack {
+                Rectangle().fill(.quaternary).frame(height: 1)
+                Text("or")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Rectangle().fill(.quaternary).frame(height: 1)
+            }
+            .padding(.horizontal, 40)
+
+            Button("Join with Invite Code") {
+                showingJoin = true
+            }
+            .font(.subheadline)
+
+            if let error = householdService.error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+            }
+
+            Spacer()
+        }
+        .sheet(isPresented: $showingJoin) {
+            JoinHouseholdView()
+        }
+    }
+
+    private func createHousehold() {
+        guard let userId = authService.currentUserId else { return }
+        Task {
+            await householdService.createHousehold(
+                name: householdName,
+                userId: userId,
+                displayName: displayName
+            )
+        }
+    }
+}

--- a/binthere/Views/Household/HouseholdView.swift
+++ b/binthere/Views/Household/HouseholdView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct HouseholdView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(HouseholdService.self) private var householdService
+
+    @State private var showingInvite = false
+
+    var body: some View {
+        List {
+            if let household = householdService.currentHousehold {
+                Section("Household") {
+                    LabeledContent("Name", value: household.name)
+                    LabeledContent("Members", value: "\(householdService.members.count)")
+                }
+
+                Section("Members") {
+                    ForEach(householdService.members) { member in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(member.displayName.isEmpty ? "Member" : member.displayName)
+                                    .font(.headline)
+                                Text(member.role.capitalized)
+                                    .font(.caption)
+                                    .foregroundStyle(roleColor(member.role))
+                            }
+
+                            Spacer()
+
+                            if member.userId.uuidString == authService.currentUserId {
+                                Text("You")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .swipeActions {
+                            if canManageMembers,
+                               member.userId.uuidString != authService.currentUserId {
+                                Button(role: .destructive) {
+                                    Task { await householdService.removeMember(memberId: member.id) }
+                                } label: {
+                                    Label("Remove", systemImage: "person.badge.minus")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !householdService.pendingInvitations.isEmpty {
+                    Section("Pending Invitations") {
+                        ForEach(householdService.pendingInvitations) { invitation in
+                            HStack {
+                                Text(invitation.inviteCode)
+                                    .font(.headline.monospaced())
+                                Spacer()
+                                Text("Expires \(invitation.expiresAt, style: .relative)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
+                if canManageMembers {
+                    Section {
+                        Button(action: { showingInvite = true }) {
+                            Label("Invite Member", systemImage: "person.badge.plus")
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Household")
+        .sheet(isPresented: $showingInvite) {
+            InviteMemberSheet()
+        }
+        .task {
+            await householdService.loadMembers()
+            await householdService.loadInvitations()
+        }
+    }
+
+    private var canManageMembers: Bool {
+        guard let userId = authService.currentUserId else { return false }
+        return householdService.members.contains {
+            $0.userId.uuidString == userId && ($0.role == "owner" || $0.role == "admin")
+        }
+    }
+
+    private func roleColor(_ role: String) -> Color {
+        switch role {
+        case "owner": .orange
+        case "admin": .blue
+        default: .secondary
+        }
+    }
+}

--- a/binthere/Views/Household/InviteMemberSheet.swift
+++ b/binthere/Views/Household/InviteMemberSheet.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct InviteMemberSheet: View {
+    @Environment(HouseholdService.self) private var householdService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var generatedCode: String?
+    @State private var isGenerating = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+
+                Image(systemName: "person.badge.plus")
+                    .font(.system(size: 60))
+                    .foregroundStyle(.blue.opacity(0.6))
+
+                Text("Invite Someone")
+                    .font(.title2.weight(.semibold))
+
+                Text("Generate a code and share it. They'll enter it in the app to join your household.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+
+                if let code = generatedCode {
+                    Text(code)
+                        .font(.system(size: 48, weight: .bold, design: .monospaced))
+                        .padding()
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .textSelection(.enabled)
+
+                    Text("Code expires in 7 days")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ShareLink(item: "Join my binthere household with code: \(code)") {
+                        Label("Share Code", systemImage: "square.and.arrow.up")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding(.horizontal, 40)
+                } else {
+                    Button(action: generateCode) {
+                        if isGenerating {
+                            ProgressView()
+                                .frame(maxWidth: .infinity, minHeight: 20)
+                        } else {
+                            Text("Generate Invite Code")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity, minHeight: 20)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isGenerating)
+                    .padding(.horizontal, 40)
+                }
+
+                if let error = householdService.error {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                Spacer()
+                Spacer()
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func generateCode() {
+        isGenerating = true
+        Task {
+            generatedCode = await householdService.generateInviteCode()
+            isGenerating = false
+        }
+    }
+}

--- a/binthere/Views/Household/JoinHouseholdView.swift
+++ b/binthere/Views/Household/JoinHouseholdView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct JoinHouseholdView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(HouseholdService.self) private var householdService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var inviteCode = ""
+    @State private var displayName = ""
+    @State private var isJoining = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+
+                Image(systemName: "house.and.flag")
+                    .font(.system(size: 60))
+                    .foregroundStyle(.green.opacity(0.6))
+
+                Text("Join a Household")
+                    .font(.title2.weight(.semibold))
+
+                Text("Enter the invite code someone shared with you.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+
+                VStack(spacing: 12) {
+                    TextField("Invite Code", text: $inviteCode)
+                        .font(.title3.monospaced())
+                        .multilineTextAlignment(.center)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                        .padding()
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    TextField("Your Name", text: $displayName)
+                        .textContentType(.name)
+                        .padding()
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .padding(.horizontal, 40)
+
+                Button(action: joinHousehold) {
+                    if isJoining {
+                        ProgressView()
+                            .frame(maxWidth: .infinity, minHeight: 20)
+                    } else {
+                        Text("Join")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity, minHeight: 20)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(inviteCode.isEmpty || displayName.isEmpty || isJoining)
+                .padding(.horizontal, 40)
+
+                if let error = householdService.error {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
+
+                Spacer()
+                Spacer()
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func joinHousehold() {
+        guard let userId = authService.currentUserId else { return }
+        isJoining = true
+        Task {
+            let success = await householdService.joinHousehold(
+                inviteCode: inviteCode,
+                userId: userId,
+                displayName: displayName
+            )
+            isJoining = false
+            if success { dismiss() }
+        }
+    }
+}

--- a/binthere/Views/Settings/SettingsView.swift
+++ b/binthere/Views/Settings/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(AuthService.self) private var authService
+    @Environment(HouseholdService.self) private var householdService
     @State private var apiKey = ImageAnalysisService.apiKey ?? ""
     @State private var showingAPIKey = false
     @State private var showingDeleteConfirmation = false
@@ -32,6 +33,28 @@ struct SettingsView: View {
                 }
             } footer: {
                 Text("This permanently deletes your account and all associated data. This cannot be undone.")
+            }
+
+            Section("Household") {
+                if let household = householdService.currentHousehold {
+                    NavigationLink {
+                        HouseholdView()
+                    } label: {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(household.name)
+                                Text("\(householdService.members.count) members")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "house")
+                        }
+                    }
+                } else {
+                    Text("No household")
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Reports & Export") {


### PR DESCRIPTION
## Summary

Phase 7, PR D — multi-user household system.

**Note:** This PR stacks on top of PR #17 (sync service). Merge that first.

**HouseholdService:**
- Create household (name + owner membership in one transaction)
- Generate 4-char invite codes with 7-day expiry
- Join household by invite code (validates, adds member, marks accepted)
- Load/update/remove members, load pending invitations

**UI Flow:**
- After sign-in, if user has no household → **HouseholdSetupView** (create or join)
- Once in a household → normal app with sync
- **Settings → Household** → **HouseholdView** with member list, roles, invitations
- **Invite Member** → generates code with share button
- **Join Household** → enter code + display name

**AuthGateView** now has a 3-step gate: Auth → Household → Main App

## Test plan

- [ ] Sign in → no household → see setup screen
- [ ] Create household → verify navigates to main app
- [ ] Settings → Household → verify member list shows you as owner
- [ ] Invite Member → generate code → share it
- [ ] Second user: join with invite code → verify they see shared data
- [ ] Owner can remove members via swipe
- [ ] Build succeeds, lint passes