### PR TITLE
feat: bulk operations — multi-select, move, delete for items and bins

### DIFF
--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -5,6 +5,7 @@ struct BinDetailView: View {
     @Environment(\.modelContext) private var modelContext
     @Bindable var bin: Bin
     @Query(sort: \Zone.name) private var allZones: [Zone]
+    @Query(sort: \Bin.code) private var allBins: [Bin]
 
     @State private var showingAddItem = false
     @State private var showingAIAnalysis = false
@@ -13,6 +14,10 @@ struct BinDetailView: View {
     @State private var nfcService = NFCService()
     @State private var showingNFCResult = false
     @State private var itemFilter: ItemFilter = .all
+    @State private var selectedItems = Set<UUID>()
+    @State private var isEditMode = false
+    @State private var showingBulkMove = false
+    @State private var showingBulkDeleteConfirmation = false
 
     enum ItemFilter: String, CaseIterable {
         case all = "All"
@@ -66,7 +71,7 @@ struct BinDetailView: View {
                 .padding(.horizontal)
             }
 
-            Section("Items (\(filteredItems.count))") {
+            Section(isEditMode ? "Select Items (\(selectedItems.count) selected)" : "Items (\(filteredItems.count))") {
                 if filteredItems.isEmpty {
                     ContentUnavailableView(
                         "No Items",
@@ -75,14 +80,30 @@ struct BinDetailView: View {
                     )
                 } else {
                     ForEach(filteredItems) { item in
-                        NavigationLink(value: item) {
-                            ItemRowView(item: item)
-                        }
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                modelContext.delete(item)
-                            } label: {
-                                Label("Delete", systemImage: "trash")
+                        if isEditMode {
+                            HStack {
+                                Image(systemName: selectedItems.contains(item.id) ? "checkmark.circle.fill" : "circle")
+                                    .foregroundStyle(selectedItems.contains(item.id) ? .blue : .secondary)
+                                ItemRowView(item: item)
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                if selectedItems.contains(item.id) {
+                                    selectedItems.remove(item.id)
+                                } else {
+                                    selectedItems.insert(item.id)
+                                }
+                            }
+                        } else {
+                            NavigationLink(value: item) {
+                                ItemRowView(item: item)
+                            }
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    modelContext.delete(item)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
                             }
                         }
                     }
@@ -94,27 +115,61 @@ struct BinDetailView: View {
             ItemDetailView(item: item)
         }
         .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                Button(action: { showingAIAnalysis = true }) {
-                    Label("AI Scan", systemImage: "sparkles")
+            if isEditMode {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        isEditMode = false
+                        selectedItems.removeAll()
+                    }
                 }
-                Button(action: { showingAddItem = true }) {
-                    Label("Add Item", systemImage: "plus")
+                ToolbarItemGroup(placement: .bottomBar) {
+                    Button(action: { showingBulkMove = true }) {
+                        Label("Move", systemImage: "arrow.right.arrow.left")
+                    }
+                    .disabled(selectedItems.isEmpty)
+
+                    Spacer()
+
+                    Button(action: selectAll) {
+                        Label(
+                            selectedItems.count == filteredItems.count ? "Deselect All" : "Select All",
+                            systemImage: selectedItems.count == filteredItems.count ? "circle" : "checkmark.circle"
+                        )
+                    }
+
+                    Spacer()
+
+                    Button(role: .destructive, action: { showingBulkDeleteConfirmation = true }) {
+                        Label("Delete", systemImage: "trash")
+                    }
+                    .disabled(selectedItems.isEmpty)
                 }
-            }
-            ToolbarItem(placement: .secondaryAction) {
-                Menu {
-                    Button(action: { showingQRCode = true }) {
-                        Label("Show QR Label", systemImage: "qrcode")
+            } else {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button(action: { showingAIAnalysis = true }) {
+                        Label("AI Scan", systemImage: "sparkles")
                     }
-                    Button(action: { nfcService.writeTag(binID: bin.id.uuidString) }) {
-                        Label("Write NFC Tag", systemImage: "wave.3.right")
+                    Button(action: { showingAddItem = true }) {
+                        Label("Add Item", systemImage: "plus")
                     }
-                    Button(action: { showingContentCamera = true }) {
-                        Label("Add Bin Photo", systemImage: "camera")
+                }
+                ToolbarItem(placement: .secondaryAction) {
+                    Menu {
+                        Button(action: { isEditMode = true }) {
+                            Label("Select Items", systemImage: "checkmark.circle")
+                        }
+                        Button(action: { showingQRCode = true }) {
+                            Label("Show QR Label", systemImage: "qrcode")
+                        }
+                        Button(action: { nfcService.writeTag(binID: bin.id.uuidString) }) {
+                            Label("Write NFC Tag", systemImage: "wave.3.right")
+                        }
+                        Button(action: { showingContentCamera = true }) {
+                            Label("Add Bin Photo", systemImage: "camera")
+                        }
+                    } label: {
+                        Label("More", systemImage: "ellipsis.circle")
                     }
-                } label: {
-                    Label("More", systemImage: "ellipsis.circle")
                 }
             }
         }
@@ -137,6 +192,38 @@ struct BinDetailView: View {
                 }
             ), sourceType: .camera)
         }
+        .sheet(isPresented: $showingBulkMove) {
+            BulkMoveSheet(items: selectedItemObjects, allBins: allBins) {
+                isEditMode = false
+                selectedItems.removeAll()
+            }
+        }
+        .alert("Delete \(selectedItems.count) Items?", isPresented: $showingBulkDeleteConfirmation) {
+            Button("Delete", role: .destructive) { bulkDelete() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This will permanently delete the selected items and their checkout history.")
+        }
+    }
+
+    private var selectedItemObjects: [Item] {
+        bin.items.filter { selectedItems.contains($0.id) }
+    }
+
+    private func selectAll() {
+        if selectedItems.count == filteredItems.count {
+            selectedItems.removeAll()
+        } else {
+            selectedItems = Set(filteredItems.map(\.id))
+        }
+    }
+
+    private func bulkDelete() {
+        for item in selectedItemObjects {
+            modelContext.delete(item)
+        }
+        selectedItems.removeAll()
+        isEditMode = false
     }
 
     private var binInfoSection: some View {
@@ -312,5 +399,43 @@ private struct QRLabelSheet: View {
         printer.printInfo = printInfo
         printer.printingItem = image
         printer.present(animated: true)
+    }
+}
+
+private struct BulkMoveSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let items: [Item]
+    let allBins: [Bin]
+    let onComplete: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List(allBins) { bin in
+                Button {
+                    for item in items {
+                        item.bin = bin
+                        item.updatedAt = Date()
+                    }
+                    onComplete()
+                    dismiss()
+                } label: {
+                    HStack {
+                        ColorDot(colorName: bin.color, size: 14)
+                        Text(bin.displayName)
+                        Spacer()
+                        Text("\(bin.items.count) items")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Move \(items.count) Items")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
     }
 }

--- a/binthere/Views/Bins/BinListView.swift
+++ b/binthere/Views/Bins/BinListView.swift
@@ -4,9 +4,14 @@ import SwiftData
 struct BinListView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Bin.code) private var bins: [Bin]
+    @Query(sort: \Zone.name) private var allZones: [Zone]
     @State private var searchText = ""
     @State private var showingAddBin = false
     @State private var groupByZone = false
+    @State private var isEditMode = false
+    @State private var selectedBins = Set<UUID>()
+    @State private var showingBulkZoneMove = false
+    @State private var showingBulkDeleteConfirmation = false
 
     private var filteredBins: [Bin] {
         if searchText.isEmpty { return bins }
@@ -77,39 +82,171 @@ struct BinListView: View {
                 }
             } else {
                 ForEach(filteredBins) { bin in
-                    NavigationLink(value: bin) {
-                        BinRowView(bin: bin)
+                    if isEditMode {
+                        HStack {
+                            Image(systemName: selectedBins.contains(bin.id) ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(selectedBins.contains(bin.id) ? .blue : .secondary)
+                            BinRowView(bin: bin)
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            if selectedBins.contains(bin.id) {
+                                selectedBins.remove(bin.id)
+                            } else {
+                                selectedBins.insert(bin.id)
+                            }
+                        }
+                    } else {
+                        NavigationLink(value: bin) {
+                            BinRowView(bin: bin)
+                        }
                     }
                 }
-                .onDelete(perform: deleteBins)
+                .onDelete(perform: isEditMode ? nil : deleteBins)
             }
         }
-        .navigationTitle("Bins")
+        .navigationTitle(isEditMode ? "\(selectedBins.count) Selected" : "Bins")
         .navigationDestination(for: Bin.self) { bin in
             BinDetailView(bin: bin)
         }
         .searchable(text: $searchText, prompt: "Search by code, label, or items")
         .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                Button(action: { groupByZone.toggle() }) {
-                    Label(
-                        groupByZone ? "Flat List" : "Group by Zone",
-                        systemImage: groupByZone ? "list.bullet" : "rectangle.3.group"
-                    )
+            if isEditMode {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        isEditMode = false
+                        selectedBins.removeAll()
+                    }
                 }
-                Button(action: { showingAddBin = true }) {
-                    Label("Add Bin", systemImage: "plus")
+                ToolbarItemGroup(placement: .bottomBar) {
+                    Button(action: { showingBulkZoneMove = true }) {
+                        Label("Move to Zone", systemImage: "mappin.and.ellipse")
+                    }
+                    .disabled(selectedBins.isEmpty)
+
+                    Spacer()
+
+                    Button(action: selectAllBins) {
+                        Label(
+                            selectedBins.count == filteredBins.count ? "Deselect All" : "Select All",
+                            systemImage: selectedBins.count == filteredBins.count ? "circle" : "checkmark.circle"
+                        )
+                    }
+
+                    Spacer()
+
+                    Button(role: .destructive, action: { showingBulkDeleteConfirmation = true }) {
+                        Label("Delete", systemImage: "trash")
+                    }
+                    .disabled(selectedBins.isEmpty)
+                }
+            } else {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Menu {
+                        Button(action: { groupByZone.toggle() }) {
+                            Label(
+                                groupByZone ? "Flat List" : "Group by Zone",
+                                systemImage: groupByZone ? "list.bullet" : "rectangle.3.group"
+                            )
+                        }
+                        Button(action: { isEditMode = true }) {
+                            Label("Select Bins", systemImage: "checkmark.circle")
+                        }
+                    } label: {
+                        Label("Options", systemImage: "ellipsis.circle")
+                    }
+
+                    Button(action: { showingAddBin = true }) {
+                        Label("Add Bin", systemImage: "plus")
+                    }
                 }
             }
         }
         .sheet(isPresented: $showingAddBin) {
             AddBinView()
         }
+        .sheet(isPresented: $showingBulkZoneMove) {
+            BulkZoneMoveSheet(bins: selectedBinObjects, allZones: allZones) {
+                isEditMode = false
+                selectedBins.removeAll()
+            }
+        }
+        .alert("Delete \(selectedBins.count) Bins?", isPresented: $showingBulkDeleteConfirmation) {
+            Button("Delete", role: .destructive) { bulkDeleteBins() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This will permanently delete the selected bins and all their items.")
+        }
+    }
+
+    private var selectedBinObjects: [Bin] {
+        bins.filter { selectedBins.contains($0.id) }
+    }
+
+    private func selectAllBins() {
+        if selectedBins.count == filteredBins.count {
+            selectedBins.removeAll()
+        } else {
+            selectedBins = Set(filteredBins.map(\.id))
+        }
     }
 
     private func deleteBins(at offsets: IndexSet) {
         for index in offsets {
             modelContext.delete(filteredBins[index])
+        }
+    }
+
+    private func bulkDeleteBins() {
+        for bin in selectedBinObjects {
+            modelContext.delete(bin)
+        }
+        selectedBins.removeAll()
+        isEditMode = false
+    }
+}
+
+private struct BulkZoneMoveSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let bins: [Bin]
+    let allZones: [Zone]
+    let onComplete: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Button {
+                    for bin in bins { bin.zone = nil; bin.updatedAt = Date() }
+                    onComplete()
+                    dismiss()
+                } label: {
+                    Label("No Zone", systemImage: "minus.circle")
+                }
+
+                ForEach(allZones) { zone in
+                    Button {
+                        for bin in bins { bin.zone = zone; bin.updatedAt = Date() }
+                        onComplete()
+                        dismiss()
+                    } label: {
+                        HStack {
+                            ZoneIcon(iconName: zone.icon, colorName: zone.color)
+                            Text(zone.name)
+                            Spacer()
+                            Text("\(zone.bins.count) bins")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Move \(bins.count) Bins")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 9 — bulk operations for managing items and bins at scale.

**BinDetailView (items):**
- "Select Items" in overflow menu enters multi-select mode
- Checkmark circles on each item row
- Bottom toolbar: Move to Bin, Select All/Deselect All, Delete
- BulkMoveSheet picks a destination bin and moves all selected items
- Bulk delete with confirmation dialog
- "Done" exits edit mode

**BinListView (bins):**
- "Select Bins" in options menu enters multi-select mode
- Bottom toolbar: Move to Zone, Select All/Deselect All, Delete
- BulkZoneMoveSheet picks a zone (or "No Zone") for all selected bins
- Bulk delete with confirmation (warns about cascading item deletion)
- Nav title shows "\(count) Selected" in edit mode

## Test plan

- [ ] Bin detail → overflow → Select Items → tap items → verify checkmarks
- [ ] Select 3 items → Move → pick a bin → verify all moved
- [ ] Select items → Delete → confirm → verify removed
- [ ] Select All → verify all items checked → Deselect All
- [ ] Done → verify exits edit mode, normal navigation restored
- [ ] Bin list → options → Select Bins → select bins → Move to Zone → verify
- [ ] Select bins → Delete → confirm → verify bins and items removed
- [ ] Build succeeds, lint passes