### PR TITLE
feat: quick add, rich swipe gestures, haptics, and context menus

### DIFF
--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -18,6 +18,10 @@ struct BinDetailView: View {
     @State private var isEditMode = false
     @State private var showingBulkMove = false
     @State private var showingBulkDeleteConfirmation = false
+    @State private var quickAddName = ""
+    @State private var showingCheckoutItem: Item?
+    @State private var showingMoveItem: Item?
+    @FocusState private var quickAddFocused: Bool
 
     enum ItemFilter: String, CaseIterable {
         case all = "All"
@@ -72,22 +76,23 @@ struct BinDetailView: View {
             }
 
             Section(isEditMode ? "Select Items (\(selectedItems.count) selected)" : "Items (\(filteredItems.count))") {
-                if filteredItems.isEmpty {
+                if filteredItems.isEmpty && quickAddName.isEmpty {
                     ContentUnavailableView(
                         "No Items",
                         systemImage: "cube.box",
-                        description: Text("Tap + or use AI Scan to add items.")
+                        description: Text("Type below to quick-add, or tap + for full details.")
                     )
                 } else {
                     ForEach(filteredItems) { item in
                         if isEditMode {
                             HStack {
                                 Image(systemName: selectedItems.contains(item.id) ? "checkmark.circle.fill" : "circle")
-                                    .foregroundStyle(selectedItems.contains(item.id) ? .blue : .secondary)
+                                    .foregroundStyle(selectedItems.contains(item.id) ? Theme.Colors.accent : Theme.Colors.secondaryText)
                                 ItemRowView(item: item)
                             }
                             .contentShape(Rectangle())
                             .onTapGesture {
+                                Haptics.selection()
                                 if selectedItems.contains(item.id) {
                                     selectedItems.remove(item.id)
                                 } else {
@@ -98,8 +103,66 @@ struct BinDetailView: View {
                             NavigationLink(value: item) {
                                 ItemRowView(item: item)
                             }
-                            .swipeActions(edge: .trailing) {
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                                 Button(role: .destructive) {
+                                    Haptics.medium()
+                                    modelContext.delete(item)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                            .swipeActions(edge: .trailing) {
+                                if item.isCheckedOut {
+                                    Button {
+                                        Haptics.success()
+                                        if let record = item.checkoutHistory.first(where: { $0.isActive }) {
+                                            record.checkedInAt = Date()
+                                        }
+                                        item.isCheckedOut = false
+                                        item.updatedAt = Date()
+                                    } label: {
+                                        Label("Check In", systemImage: "arrow.down.to.line")
+                                    }
+                                    .tint(Theme.Colors.success)
+                                }
+                            }
+                            .swipeActions(edge: .leading) {
+                                if !item.isCheckedOut && item.checkoutPermission != "none" {
+                                    Button {
+                                        showingCheckoutItem = item
+                                    } label: {
+                                        Label("Check Out", systemImage: "arrow.up.right")
+                                    }
+                                    .tint(Theme.Colors.checkedOut)
+                                }
+                            }
+                            .contextMenu {
+                                if item.isCheckedOut {
+                                    Button {
+                                        Haptics.success()
+                                        if let record = item.checkoutHistory.first(where: { $0.isActive }) {
+                                            record.checkedInAt = Date()
+                                        }
+                                        item.isCheckedOut = false
+                                        item.updatedAt = Date()
+                                    } label: {
+                                        Label("Check In", systemImage: "arrow.down.to.line")
+                                    }
+                                } else if item.checkoutPermission != "none" {
+                                    Button {
+                                        showingCheckoutItem = item
+                                    } label: {
+                                        Label("Check Out", systemImage: "arrow.up.right")
+                                    }
+                                }
+                                Button {
+                                    showingMoveItem = item
+                                } label: {
+                                    Label("Move to Bin", systemImage: "arrow.right.arrow.left")
+                                }
+                                Divider()
+                                Button(role: .destructive) {
+                                    Haptics.medium()
                                     modelContext.delete(item)
                                 } label: {
                                     Label("Delete", systemImage: "trash")
@@ -107,6 +170,20 @@ struct BinDetailView: View {
                             }
                         }
                     }
+                }
+
+                // Quick add row
+                if !isEditMode {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundStyle(Theme.Colors.accent)
+                        TextField("Add item...", text: $quickAddName)
+                            .font(Theme.Typography.body)
+                            .focused($quickAddFocused)
+                            .onSubmit { quickAddItem() }
+                            .submitLabel(.done)
+                    }
+                    .padding(.vertical, Theme.Spacing.xxs)
                 }
             }
         }
@@ -207,6 +284,14 @@ struct BinDetailView: View {
         } message: {
             Text("This will permanently delete the selected items and their checkout history.")
         }
+        .sheet(item: $showingCheckoutItem) { item in
+            CheckoutSheet(item: item, defaultName: "")
+                .cardPresentation()
+        }
+        .sheet(item: $showingMoveItem) { item in
+            MoveBinSheet(item: item, bins: allBins)
+                .cardPresentation()
+        }
     }
 
     private var selectedItemObjects: [Item] {
@@ -222,11 +307,23 @@ struct BinDetailView: View {
     }
 
     private func bulkDelete() {
+        Haptics.success()
         for item in selectedItemObjects {
             modelContext.delete(item)
         }
         selectedItems.removeAll()
         isEditMode = false
+    }
+
+    private func quickAddItem() {
+        let name = quickAddName.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+        let item = Item(name: name, bin: bin)
+        modelContext.insert(item)
+        Haptics.light()
+        withAnimation(Theme.Animation.spring) {
+            quickAddName = ""
+        }
     }
 
     private var binInfoSection: some View {

--- a/binthere/Views/Bins/BinListView.swift
+++ b/binthere/Views/Bins/BinListView.swift
@@ -100,6 +100,20 @@ struct BinListView: View {
                         NavigationLink(value: bin) {
                             BinRowView(bin: bin)
                         }
+                        .contextMenu {
+                            Button {
+                                // QR label handled via navigation
+                            } label: {
+                                Label("Show QR Label", systemImage: "qrcode")
+                            }
+                            Divider()
+                            Button(role: .destructive) {
+                                Haptics.medium()
+                                modelContext.delete(bin)
+                            } label: {
+                                Label("Delete Bin", systemImage: "trash")
+                            }
+                        }
                     }
                 }
                 .onDelete(perform: isEditMode ? nil : deleteBins)

--- a/binthere/Views/Items/ItemDetailView.swift
+++ b/binthere/Views/Items/ItemDetailView.swift
@@ -323,7 +323,7 @@ private struct CheckoutRecordRow: View {
     }
 }
 
-private struct CheckoutSheet: View {
+struct CheckoutSheet: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     let item: Item
@@ -398,7 +398,7 @@ private struct CheckoutSheet: View {
     }
 }
 
-private struct MoveBinSheet: View {
+struct MoveBinSheet: View {
     @Environment(\.dismiss) private var dismiss
     let item: Item
     let bins: [Bin]


### PR DESCRIPTION
## Summary

Phase 11, PR C — the core interaction feel.

**Quick add:**
- Persistent "Add item..." text field at the bottom of every bin's item list
- Type a name, hit return → item created instantly with light haptic
- No sheet, no extra taps. Things-style speed.

**Rich swipe actions:**
- Swipe left (full): delete with medium haptic
- Swipe left (short): check in (green) with success haptic
- Swipe right: check out (orange) — opens checkout sheet
- Permission-aware: locked items don't show checkout swipe

**Context menus (long-press):**
- Items: check in/out, move to bin, delete
- Bins: show QR label, delete

**Haptic feedback:**
- `Haptics.light()` on item creation
- `Haptics.medium()` on delete
- `Haptics.success()` on check-in and bulk operations
- `Haptics.selection()` on multi-select toggle

**Accessibility:** CheckoutSheet and MoveBinSheet made internal for reuse from context menu actions.

## Test plan

- [ ] Bin detail → type in quick add field → hit return → item appears with haptic
- [ ] Swipe item left → red delete with full swipe
- [ ] Swipe checked-out item left short → green check in
- [ ] Swipe item right → orange check out sheet
- [ ] Long-press item → context menu with check out, move, delete
- [ ] Long-press bin in list → context menu with QR and delete
- [ ] Multi-select → toggle selection → feel selection haptic
- [ ] Build succeeds, lint passes