### PR TITLE
feat: branded empty states, accessibility, and keyboard shortcuts

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		AB00000100000010AAAAAA01 /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000010BBBBBB01 /* StorageService.swift */; };
 		AB00000100000011AAAAAA01 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000011BBBBBB01 /* Theme.swift */; };
 		AB00000100000012AAAAAA01 /* CardPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000012BBBBBB01 /* CardPresentation.swift */; };
+		AB00000100000013AAAAAA01 /* BrandedEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000100000013BBBBBB01 /* BrandedEmptyState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -143,6 +144,7 @@
 		AB00000100000010BBBBBB01 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		AB00000100000011BBBBBB01 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		AB00000100000012BBBBBB01 /* CardPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentation.swift; sourceTree = "<group>"; };
+		AB00000100000013BBBBBB01 /* BrandedEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandedEmptyState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -330,6 +332,7 @@
 				EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */,
 				AB00000100000011BBBBBB01 /* Theme.swift */,
 				AB00000100000012BBBBBB01 /* CardPresentation.swift */,
+				AB00000100000013BBBBBB01 /* BrandedEmptyState.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -559,6 +562,7 @@
 				AB00000100000010AAAAAA01 /* StorageService.swift in Sources */,
 				AB00000100000011AAAAAA01 /* Theme.swift in Sources */,
 				AB00000100000012AAAAAA01 /* CardPresentation.swift in Sources */,
+				AB00000100000013AAAAAA01 /* BrandedEmptyState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/binthere/Utilities/BrandedEmptyState.swift
+++ b/binthere/Utilities/BrandedEmptyState.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct BrandedEmptyState: View {
+    let icon: String
+    let title: String
+    let message: String
+    var gradient: [Color] = [.blue.opacity(0.6), .blue.opacity(0.3)]
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: gradient,
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 80, height: 80)
+
+                Image(systemName: icon)
+                    .font(.system(size: 34))
+                    .foregroundStyle(.white)
+            }
+
+            Text(title)
+                .font(Theme.Typography.title3)
+                .foregroundStyle(Theme.Colors.primaryText)
+
+            Text(message)
+                .font(Theme.Typography.subheadline)
+                .foregroundStyle(Theme.Colors.secondaryText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .padding(.vertical, Theme.Spacing.xxl)
+        .frame(maxWidth: .infinity)
+        .opacity(appeared ? 1 : 0)
+        .scaleEffect(appeared ? 1 : 0.9)
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(Theme.Animation.spring.delay(0.1)) {
+                    appeared = true
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title). \(message)")
+    }
+}
+
+// MARK: - Preset Empty States
+
+extension BrandedEmptyState {
+    static var noBins: BrandedEmptyState {
+        BrandedEmptyState(
+            icon: "archivebox",
+            title: "Your bins are waiting",
+            message: "Tap + to create your first bin and start organizing.",
+            gradient: [.blue.opacity(0.7), .cyan.opacity(0.4)]
+        )
+    }
+
+    static var noItems: BrandedEmptyState {
+        BrandedEmptyState(
+            icon: "cube.box",
+            title: "This bin is empty",
+            message: "Type below to quick-add items, or tap + for full details.",
+            gradient: [.purple.opacity(0.7), .purple.opacity(0.3)]
+        )
+    }
+
+    static var noZones: BrandedEmptyState {
+        BrandedEmptyState(
+            icon: "square.grid.2x2",
+            title: "Organize your space",
+            message: "Zones represent rooms or areas. Tap + to create one.",
+            gradient: [.green.opacity(0.7), .mint.opacity(0.4)]
+        )
+    }
+
+    static var noCheckoutHistory: BrandedEmptyState {
+        BrandedEmptyState(
+            icon: "clock.arrow.circlepath",
+            title: "No checkout history",
+            message: "Checkout records will appear here.",
+            gradient: [.orange.opacity(0.7), .yellow.opacity(0.4)]
+        )
+    }
+
+    static var noSearchResults: BrandedEmptyState {
+        BrandedEmptyState(
+            icon: "magnifyingglass",
+            title: "No results",
+            message: "No bins match your search.",
+            gradient: [.gray.opacity(0.5), .gray.opacity(0.3)]
+        )
+    }
+}

--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -77,11 +77,7 @@ struct BinDetailView: View {
 
             Section(isEditMode ? "Select Items (\(selectedItems.count) selected)" : "Items (\(filteredItems.count))") {
                 if filteredItems.isEmpty && quickAddName.isEmpty {
-                    ContentUnavailableView(
-                        "No Items",
-                        systemImage: "cube.box",
-                        description: Text("Type below to quick-add, or tap + for full details.")
-                    )
+                    BrandedEmptyState.noItems
                 } else {
                     ForEach(filteredItems) { item in
                         if isEditMode {

--- a/binthere/Views/Bins/BinListView.swift
+++ b/binthere/Views/Bins/BinListView.swift
@@ -50,11 +50,11 @@ struct BinListView: View {
     var body: some View {
         List {
             if filteredBins.isEmpty {
-                ContentUnavailableView(
-                    searchText.isEmpty ? "No Bins Yet" : "No Results",
-                    systemImage: searchText.isEmpty ? "archivebox" : "magnifyingglass",
-                    description: Text(searchText.isEmpty ? "Tap + to create your first bin." : "No bins match your search.")
-                )
+                if searchText.isEmpty {
+                    BrandedEmptyState.noBins
+                } else {
+                    BrandedEmptyState.noSearchResults
+                }
             } else if groupByZone {
                 ForEach(groupedBins, id: \.zone?.id) { group in
                     Section {
@@ -173,6 +173,8 @@ struct BinListView: View {
                     Button(action: { showingAddBin = true }) {
                         Label("Add Bin", systemImage: "plus")
                     }
+                    .keyboardShortcut("n", modifiers: .command)
+                    .accessibilityIdentifier("addBinButton")
                 }
             }
         }

--- a/binthere/Views/MainTabView.swift
+++ b/binthere/Views/MainTabView.swift
@@ -1,14 +1,18 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @State private var selectedTab = 0
+
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             NavigationStack {
                 BinListView()
             }
             .tabItem {
                 Label("Bins", systemImage: "archivebox")
             }
+            .tag(0)
+            .accessibilityIdentifier("binsTab")
 
             NavigationStack {
                 ZonesGridView()
@@ -16,6 +20,8 @@ struct MainTabView: View {
             .tabItem {
                 Label("Zones", systemImage: "square.grid.2x2")
             }
+            .tag(1)
+            .accessibilityIdentifier("zonesTab")
 
             NavigationStack {
                 ScannerTab()
@@ -23,6 +29,8 @@ struct MainTabView: View {
             .tabItem {
                 Label("Scan", systemImage: "qrcode.viewfinder")
             }
+            .tag(2)
+            .accessibilityIdentifier("scanTab")
 
             NavigationStack {
                 SettingsView()
@@ -30,6 +38,8 @@ struct MainTabView: View {
             .tabItem {
                 Label("Settings", systemImage: "gear")
             }
+            .tag(3)
+            .accessibilityIdentifier("settingsTab")
         }
     }
 }

--- a/binthere/Views/Zones/ZonesGridView.swift
+++ b/binthere/Views/Zones/ZonesGridView.swift
@@ -14,12 +14,8 @@ struct ZonesGridView: View {
     var body: some View {
         ScrollView {
             if zones.isEmpty {
-                ContentUnavailableView(
-                    "No Zones",
-                    systemImage: "square.grid.2x2",
-                    description: Text("Zones represent rooms or areas. Tap + to create one.")
-                )
-                .padding(.top, 60)
+                BrandedEmptyState.noZones
+                    .padding(.top, Theme.Spacing.xxl)
             } else {
                 LazyVGrid(columns: columns, spacing: Theme.Spacing.md) {
                     ForEach(zones) { zone in


### PR DESCRIPTION
## Summary

Phase 11, PR D — the final polish pass.

**Branded empty states:**
- Custom component with gradient circle icon, title, message
- Fade + scale entry animation (respects Reduce Motion)
- Combined VoiceOver label for accessibility
- Applied to: bin list (blue), bin detail (purple), zones grid (green), search results (gray)

**Accessibility:**
- `accessibilityIdentifier` on tab bar items and key buttons (for UI testing)
- `accessibilityReduceMotion` respected in all entry animations
- `accessibilityElement(children: .combine)` on empty states for VoiceOver

**Keyboard shortcuts (iPad):**
- `Cmd+N`: create new bin from bin list
- `Cmd+F`: focus search (native SwiftUI support)

**MainTabView:** tag-based tab selection for programmatic navigation.

## Test plan

- [ ] Empty bin list → verify gradient icon + "Your bins are waiting" with animation
- [ ] Empty bin → verify purple "This bin is empty"
- [ ] Empty zones → verify green "Organize your space"
- [ ] Search with no results → verify gray "No results"
- [ ] Enable Reduce Motion → verify no animations on empty states
- [ ] VoiceOver: navigate empty state → verify combined label read
- [ ] iPad: Cmd+N → verify new bin sheet opens
- [ ] iPad: Cmd+F → verify search focuses
- [ ] Build succeeds, lint passes