### PR TITLE
feat: add Google Sign-In authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ Package.resolved
 
 # Secrets
 Secrets.xcconfig
+GoogleService-Info.plist
+client_*.apps.googleusercontent.com.plist
 .env
 .env.*
 

--- a/binthere/Info.plist
+++ b/binthere/Info.plist
@@ -6,5 +6,16 @@
 	<string>$(SUPABASE_URL)</string>
 	<key>SUPABASE_ANON_KEY</key>
 	<string>$(SUPABASE_ANON_KEY)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.126790508102-us31jlq55g59a02o68m3ream9vpmrb5o</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>Google Sign-In</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/binthere/Info.plist
+++ b/binthere/Info.plist
@@ -12,9 +12,10 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.googleusercontent.apps.126790508102-us31jlq55g59a02o68m3ream9vpmrb5o</string>
+				<string>beeBetter.binthere</string>
 			</array>
 			<key>CFBundleURLName</key>
-			<string>Google Sign-In</string>
+			<string>Auth Callback</string>
 		</dict>
 	</array>
 </dict>

--- a/binthere/Services/AuthService.swift
+++ b/binthere/Services/AuthService.swift
@@ -113,6 +113,20 @@ final class AuthService {
         }
     }
 
+    // MARK: - Sign in with Google
+
+    func signInWithGoogle() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            try await client.auth.signInWithOAuth(provider: .google)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
     // MARK: - Sign Out
 
     func signOut() async {

--- a/binthere/Services/SupabaseConfig.swift
+++ b/binthere/Services/SupabaseConfig.swift
@@ -10,5 +10,10 @@ import Supabase
 
 let supabase = SupabaseClient(
     supabaseURL: URL(string: "https://graxolpusjcqlzikbnpr.supabase.co")!,
-    supabaseKey: "sb_publishable_1O3xXBqBCO-g_-gdgyFUSA_UmSpp7RJ"
+    supabaseKey: "sb_publishable_1O3xXBqBCO-g_-gdgyFUSA_UmSpp7RJ",
+    options: .init(
+        auth: .init(
+            redirectToURL: URL(string: "beeBetter.binthere://auth-callback")
+        )
+    )
 )

--- a/binthere/Views/Auth/SignInView.swift
+++ b/binthere/Views/Auth/SignInView.swift
@@ -35,6 +35,25 @@ struct SignInView: View {
             .frame(height: 50)
             .padding(.horizontal, 40)
 
+            // Sign in with Google
+            Button(action: { Task { await authService.signInWithGoogle() } }) {
+                HStack(spacing: 12) {
+                    Image(systemName: "g.circle.fill")
+                        .font(.title2)
+                    Text("Sign in with Google")
+                        .font(.headline)
+                }
+                .frame(maxWidth: .infinity, minHeight: 50)
+                .background(.white)
+                .foregroundStyle(.black)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(.quaternary, lineWidth: 1)
+                )
+            }
+            .padding(.horizontal, 40)
+
             // Divider
             HStack {
                 Rectangle().fill(.quaternary).frame(height: 1)

--- a/binthere/binthereApp.swift
+++ b/binthere/binthereApp.swift
@@ -27,6 +27,12 @@ struct binthereApp: App { // swiftlint:disable:this type_name
     var body: some Scene {
         WindowGroup {
             AuthGateView()
+                .onOpenURL { url in
+                    // Handle OAuth callback (Google Sign-In redirect)
+                    Task {
+                        await supabase.auth.handle(url)
+                    }
+                }
         }
         .modelContainer(sharedModelContainer)
     }


### PR DESCRIPTION
## Summary

Adds Google as a third auth option alongside Apple and email/password.

- Google Sign-In button on sign-in screen
- Supabase OAuth flow (`signInWithOAuth(provider: .google)`)
- OAuth callback handling via `onOpenURL` in app entry point
- Reversed client ID URL scheme in Info.plist for redirect
- GoogleService-Info.plist gitignored

### Setup required
1. Create a **Web Application** OAuth client in Google Cloud Console
2. Set redirect URI: `https://graxolpusjcqlzikbnpr.supabase.co/auth/v1/callback`
3. In Supabase: **Authentication → Providers → Google** → enable, enter Client ID + Client Secret from the web client

## Test plan

- [ ] Google Sign-In button visible on sign-in screen
- [ ] Tap Google → opens OAuth flow in browser
- [ ] After Google auth → redirects back to app → signed in
- [ ] Build succeeds, lint passes