### PR TITLE
feat: bulk AI valuation, inline AI editing, color picker fix, collapsible icons

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */; };
 		EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000003BBBBBB01 /* SetValueSheet.swift */; };
 		EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */; };
+		EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */; };
 		FF00000100000001AAAAAA01 /* ReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000001BBBBBB01 /* ReportService.swift */; };
 		FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */; };
 		FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000003BBBBBB01 /* ReportsView.swift */; };
@@ -146,6 +147,7 @@
 		EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		EE00000100000003BBBBBB01 /* SetValueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetValueSheet.swift; sourceTree = "<group>"; };
 		EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributeSheet.swift; sourceTree = "<group>"; };
+		EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkValuationSheet.swift; sourceTree = "<group>"; };
 		FF00000100000001BBBBBB01 /* ReportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportService.swift; sourceTree = "<group>"; };
 		FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDashboardView.swift; sourceTree = "<group>"; };
 		FF00000100000003BBBBBB01 /* ReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportsView.swift; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				AA0000010000000BBBBBBB01 /* AIAnalysisView.swift */,
 				EE00000100000003BBBBBB01 /* SetValueSheet.swift */,
 				EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */,
+				EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */,
 				AB0000010000000EBBBBBB01 /* RequestItemSheet.swift */,
 			);
 			path = Items;
@@ -550,6 +553,7 @@
 				EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */,
 				EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */,
 				EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */,
+				EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */,
 				FF00000100000001AAAAAA01 /* ReportService.swift in Sources */,
 				FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */,
 				FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */,

--- a/binthere/Services/ImageAnalysisService.swift
+++ b/binthere/Services/ImageAnalysisService.swift
@@ -6,7 +6,19 @@ struct SuggestedItem: Identifiable {
     var name: String
     var description: String
     var tags: [String]
+    var color: String = ""
+    var value: Double?
     var isSelected: Bool = true
+
+    var tagsText: String {
+        get { tags.joined(separator: ", ") }
+        set {
+            tags = newValue
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+        }
+    }
 }
 
 enum ImageAnalysisError: LocalizedError {
@@ -310,6 +322,141 @@ final class ImageAnalysisService {
 
         let reasoning = parsed["reasoning"] as? String ?? ""
         return ValueEstimate(value: estimatedValue, reasoning: reasoning)
+    }
+
+    // MARK: - Bulk Value Estimation
+
+    struct BulkValueResult: Identifiable {
+        let id: UUID
+        let value: Double
+        let reasoning: String
+    }
+
+    /// Items to estimate values for. The id matches up with the result.
+    struct BulkValueInput {
+        let id: UUID
+        let name: String
+        let description: String
+    }
+
+    /// Estimate values for a batch of items in a single AI call.
+    /// Returns a dictionary keyed by the input id.
+    func estimateValuesBulk(items: [BulkValueInput]) async -> [UUID: BulkValueResult] {
+        guard !items.isEmpty else { return [:] }
+
+        guard let apiKey = Self.apiKey, !apiKey.isEmpty else {
+            error = .noAPIKey
+            return [:]
+        }
+
+        isAnalyzing = true
+        error = nil
+        defer { isAnalyzing = false }
+
+        let itemsList = items.enumerated().map { index, item in
+            "\(index + 1). \(item.name)" +
+                (item.description.isEmpty ? "" : " — \(item.description)")
+        }.joined(separator: "\n")
+
+        let prompt = """
+        Estimate the current resale value of each of the following items in US dollars.
+        Use typical market prices for similar items in average used condition.
+
+        Items:
+        \(itemsList)
+
+        Respond with ONLY a JSON array of objects, one per item in the same order, \
+        each with: "index" (the item number from the list, 1-based), \
+        "estimated_value" (a number in USD, no currency symbol), \
+        "reasoning" (a brief 1-2 sentence explanation).
+        Example: [{"index": 1, "estimated_value": 25.00, "reasoning": "Used hand tool, \
+        retails for $20-30."}]
+        Return ONLY the JSON array, no other text.
+        """
+
+        guard let request = buildBulkValueRequest(apiKey: apiKey, prompt: prompt) else {
+            error = .decodingError("Failed to create request")
+            return [:]
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            return try parseBulkValueResponse(data, inputs: items)
+        } catch let analysisError as ImageAnalysisError {
+            error = analysisError
+            return [:]
+        } catch {
+            self.error = .networkError(error)
+            return [:]
+        }
+    }
+
+    private func buildBulkValueRequest(apiKey: String, prompt: String) -> URLRequest? {
+        let requestBody: [String: Any] = [
+            "model": "claude-sonnet-4-5",
+            "max_tokens": 4096,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": [
+                        ["type": "text", "text": prompt],
+                    ],
+                ],
+            ],
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: requestBody),
+              let apiURL = URL(string: "https://api.anthropic.com/v1/messages") else {
+            return nil
+        }
+
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.httpBody = jsonData
+        return request
+    }
+
+    private func parseBulkValueResponse(
+        _ data: Data,
+        inputs: [BulkValueInput]
+    ) throws -> [UUID: BulkValueResult] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ImageAnalysisError.decodingError("Response is not valid JSON")
+        }
+
+        if let errorDict = json["error"] as? [String: Any],
+           let message = errorDict["message"] as? String {
+            throw ImageAnalysisError.decodingError("API error: \(message)")
+        }
+
+        guard let content = json["content"] as? [[String: Any]],
+              let firstBlock = content.first,
+              let text = firstBlock["text"] as? String else {
+            throw ImageAnalysisError.decodingError("Unexpected response format")
+        }
+
+        let cleaned = Self.extractJSONArray(from: text)
+        guard let arrayData = cleaned.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: arrayData) as? [[String: Any]] else {
+            print("[ImageAnalysisService] Could not parse bulk values from text: \(text)")
+            throw ImageAnalysisError.decodingError("Could not parse bulk value estimates")
+        }
+
+        var results: [UUID: BulkValueResult] = [:]
+        for entry in parsed {
+            guard let index = entry["index"] as? Int,
+                  index >= 1, index <= inputs.count,
+                  let value = entry["estimated_value"] as? Double else {
+                continue
+            }
+            let input = inputs[index - 1]
+            let reasoning = entry["reasoning"] as? String ?? ""
+            results[input.id] = BulkValueResult(id: input.id, value: value, reasoning: reasoning)
+        }
+        return results
     }
 
     /// Extracts a JSON object from text that may be wrapped in markdown code fences.

--- a/binthere/Utilities/ColorPalette.swift
+++ b/binthere/Utilities/ColorPalette.swift
@@ -51,23 +51,30 @@ struct ColorPickerRow: View {
     @Binding var selectedColor: String
 
     var body: some View {
-        HStack(spacing: 10) {
-            ForEach(ColorPalette.selectableColors) { palette in
-                Circle()
-                    .fill(palette.color)
-                    .frame(width: 30, height: 30)
-                    .overlay {
-                        if selectedColor == palette.rawValue {
-                            Circle()
-                                .strokeBorder(.white, lineWidth: 2)
-                                .frame(width: 24, height: 24)
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(ColorPalette.selectableColors) { palette in
+                    Circle()
+                        .fill(palette.color)
+                        .frame(width: 32, height: 32)
+                        .overlay {
+                            if selectedColor == palette.rawValue {
+                                Circle()
+                                    .strokeBorder(.white, lineWidth: 2)
+                                    .frame(width: 26, height: 26)
+                            }
                         }
-                    }
-                    .shadow(color: selectedColor == palette.rawValue ? palette.color.opacity(0.5) : .clear, radius: 4)
-                    .onTapGesture {
-                        selectedColor = selectedColor == palette.rawValue ? "" : palette.rawValue
-                    }
+                        .shadow(
+                            color: selectedColor == palette.rawValue ? palette.color.opacity(0.5) : .clear,
+                            radius: 4
+                        )
+                        .padding(.vertical, 4)
+                        .onTapGesture {
+                            selectedColor = selectedColor == palette.rawValue ? "" : palette.rawValue
+                        }
+                }
             }
+            .padding(.horizontal, 4)
         }
     }
 }

--- a/binthere/Utilities/IconPalette.swift
+++ b/binthere/Utilities/IconPalette.swift
@@ -35,41 +35,91 @@ enum IconPalette {
 
 struct IconPickerGrid: View {
     @Binding var selectedIcon: String
+    @State private var expandedGroups: Set<String> = []
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 6)
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             ForEach(IconPalette.groups) { group in
-                Text(group.name)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .center)
+                groupSection(group)
+            }
+        }
+        .onAppear { autoExpandSelectedGroup() }
+    }
 
-                LazyVGrid(columns: columns, spacing: 12) {
-                    ForEach(group.icons, id: \.self) { icon in
-                        Image(systemName: icon)
-                            .font(.title3)
-                            .frame(width: 40, height: 40)
-                            .background(
-                                selectedIcon == icon
-                                    ? Color.accentColor.opacity(0.15)
-                                    : Color.clear
-                            )
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .strokeBorder(
-                                        selectedIcon == icon ? Color.accentColor : Color.clear,
-                                        lineWidth: 2
-                                    )
-                            )
-                            .onTapGesture {
-                                selectedIcon = selectedIcon == icon ? "" : icon
-                            }
-                    }
+    @ViewBuilder
+    private func groupSection(_ group: IconPalette.IconGroup) -> some View {
+        let isExpanded = expandedGroups.contains(group.id)
+
+        Button(action: { toggleGroup(group.id) }) {
+            HStack {
+                Text(group.name)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.primary)
+
+                if let preview = group.icons.first(where: { $0 == selectedIcon }) {
+                    Image(systemName: preview)
+                        .font(.caption)
+                        .foregroundStyle(Color.accentColor)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+
+        if isExpanded {
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(group.icons, id: \.self) { icon in
+                    Image(systemName: icon)
+                        .font(.title3)
+                        .frame(width: 40, height: 40)
+                        .background(
+                            selectedIcon == icon
+                                ? Color.accentColor.opacity(0.15)
+                                : Color.clear
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .strokeBorder(
+                                    selectedIcon == icon ? Color.accentColor : Color.clear,
+                                    lineWidth: 2
+                                )
+                        )
+                        .onTapGesture {
+                            selectedIcon = selectedIcon == icon ? "" : icon
+                        }
                 }
             }
+            .padding(.bottom, 8)
+            .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+
+        Divider()
+    }
+
+    private func toggleGroup(_ id: String) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            if expandedGroups.contains(id) {
+                expandedGroups.remove(id)
+            } else {
+                expandedGroups.insert(id)
+            }
+        }
+    }
+
+    private func autoExpandSelectedGroup() {
+        for group in IconPalette.groups where group.icons.contains(selectedIcon) {
+            expandedGroups.insert(group.id)
         }
     }
 }

--- a/binthere/Views/Bins/AddBinView.swift
+++ b/binthere/Views/Bins/AddBinView.swift
@@ -408,39 +408,103 @@ struct AddBinView: View {
                 bin: bin
             )
             item.tags = suggestion.tags
+            item.color = suggestion.color
+            item.householdId = bin.householdId
+            item.updatedAt = Date()
+            if let value = suggestion.value {
+                item.value = value
+                item.valueSource = "ai"
+                item.valueUpdatedAt = Date()
+            }
             if let path = contentImagePath {
                 item.imagePaths = [path]
             }
             modelContext.insert(item)
         }
 
+        try? modelContext.save()
         dismiss()
     }
 }
 
 private struct SuggestedItemRow: View {
     @Binding var suggestion: SuggestedItem
+    @State private var expanded = false
+    @State private var valueText = ""
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Toggle("", isOn: $suggestion.isSelected)
-                .labelsHidden()
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 12) {
+                Toggle("", isOn: $suggestion.isSelected)
+                    .labelsHidden()
 
-            VStack(alignment: .leading, spacing: 6) {
-                TextField("Name", text: $suggestion.name)
-                    .font(.headline)
-                TextField("Description", text: $suggestion.description, axis: .vertical)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2...4)
-                if !suggestion.tags.isEmpty {
-                    Text(suggestion.tags.joined(separator: ", "))
-                        .font(.caption)
-                        .foregroundStyle(.blue)
+                VStack(alignment: .leading, spacing: 6) {
+                    TextField("Name", text: $suggestion.name)
+                        .font(.headline)
+                    TextField("Description", text: $suggestion.description, axis: .vertical)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2...4)
                 }
+
+                Spacer(minLength: 0)
+
+                Button(action: { withAnimation { expanded.toggle() } }) {
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(8)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if expanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Tags")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 60, alignment: .leading)
+                        TextField("Comma separated", text: Binding(
+                            get: { suggestion.tagsText },
+                            set: { suggestion.tagsText = $0 }
+                        ))
+                        .font(.caption)
+                    }
+
+                    HStack {
+                        Text("Color")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 60, alignment: .leading)
+                        ColorPickerRow(selectedColor: $suggestion.color)
+                    }
+
+                    HStack {
+                        Text("Value")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 60, alignment: .leading)
+                        Text("$")
+                            .foregroundStyle(.secondary)
+                        TextField("0.00", text: $valueText)
+                            .font(.caption)
+                            .keyboardType(.decimalPad)
+                            .onChange(of: valueText) { _, newValue in
+                                suggestion.value = Double(newValue.filter { $0.isNumber || $0 == "." })
+                            }
+                    }
+                }
+                .padding(.leading, 40)
+                .transition(.opacity)
             }
         }
         .opacity(suggestion.isSelected ? 1 : 0.5)
         .padding(.vertical, 4)
+        .onAppear {
+            if let val = suggestion.value {
+                valueText = String(format: "%.2f", val)
+            }
+        }
     }
 }

--- a/binthere/Views/Bins/BinDetailView.swift
+++ b/binthere/Views/Bins/BinDetailView.swift
@@ -18,6 +18,7 @@ struct BinDetailView: View {
     @State private var isEditMode = false
     @State private var showingBulkMove = false
     @State private var showingBulkDeleteConfirmation = false
+    @State private var showingBulkValuation = false
     @State private var quickAddName = ""
     @State private var showingCheckoutItem: Item?
     @State private var showingMoveItem: Item?
@@ -231,6 +232,10 @@ struct BinDetailView: View {
                         Button(action: { isEditMode = true }) {
                             Label("Select Items", systemImage: "checkmark.circle")
                         }
+                        Button(action: { showingBulkValuation = true }) {
+                            Label("Estimate Values with AI", systemImage: "sparkles")
+                        }
+                        .disabled(bin.items.isEmpty)
                         Button(action: { showingQRCode = true }) {
                             Label("Show QR Label", systemImage: "qrcode")
                         }
@@ -273,6 +278,13 @@ struct BinDetailView: View {
                 isEditMode = false
                 selectedItems.removeAll()
             }
+        }
+        .sheet(isPresented: $showingBulkValuation) {
+            BulkValuationSheet(
+                title: "Estimate Values: \(bin.code)",
+                items: bin.items
+            )
+            .cardPresentation()
         }
         .alert("Delete \(selectedItems.count) Items?", isPresented: $showingBulkDeleteConfirmation) {
             Button("Delete", role: .destructive) { bulkDelete() }

--- a/binthere/Views/Items/AIAnalysisView.swift
+++ b/binthere/Views/Items/AIAnalysisView.swift
@@ -171,39 +171,103 @@ struct AIAnalysisView: View {
                 bin: bin
             )
             item.tags = suggestion.tags
+            item.color = suggestion.color
+            item.householdId = bin.householdId
+            item.updatedAt = Date()
+            if let value = suggestion.value {
+                item.value = value
+                item.valueSource = "ai"
+                item.valueUpdatedAt = Date()
+            }
             if let path = imagePath {
                 item.imagePaths = [path]
             }
             modelContext.insert(item)
         }
 
+        try? modelContext.save()
         dismiss()
     }
 }
 
 private struct SuggestedItemRow: View {
     @Binding var suggestion: SuggestedItem
+    @State private var expanded = false
+    @State private var valueText = ""
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Toggle("", isOn: $suggestion.isSelected)
-                .labelsHidden()
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 12) {
+                Toggle("", isOn: $suggestion.isSelected)
+                    .labelsHidden()
 
-            VStack(alignment: .leading, spacing: 6) {
-                TextField("Name", text: $suggestion.name)
-                    .font(.headline)
-                TextField("Description", text: $suggestion.description, axis: .vertical)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2...4)
-                if !suggestion.tags.isEmpty {
-                    Text(suggestion.tags.joined(separator: ", "))
-                        .font(.caption)
-                        .foregroundStyle(.blue)
+                VStack(alignment: .leading, spacing: 6) {
+                    TextField("Name", text: $suggestion.name)
+                        .font(.headline)
+                    TextField("Description", text: $suggestion.description, axis: .vertical)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2...4)
                 }
+
+                Spacer(minLength: 0)
+
+                Button(action: { withAnimation { expanded.toggle() } }) {
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(8)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if expanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Tags")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 60, alignment: .leading)
+                        TextField("Comma separated", text: Binding(
+                            get: { suggestion.tagsText },
+                            set: { suggestion.tagsText = $0 }
+                        ))
+                        .font(.caption)
+                    }
+
+                    HStack {
+                        Text("Color")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 60, alignment: .leading)
+                        ColorPickerRow(selectedColor: $suggestion.color)
+                    }
+
+                    HStack {
+                        Text("Value")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 60, alignment: .leading)
+                        Text("$")
+                            .foregroundStyle(.secondary)
+                        TextField("0.00", text: $valueText)
+                            .font(.caption)
+                            .keyboardType(.decimalPad)
+                            .onChange(of: valueText) { _, newValue in
+                                suggestion.value = Double(newValue.filter { $0.isNumber || $0 == "." })
+                            }
+                    }
+                }
+                .padding(.leading, 40)
+                .transition(.opacity)
             }
         }
         .opacity(suggestion.isSelected ? 1 : 0.5)
         .padding(.vertical, 4)
+        .onAppear {
+            if let val = suggestion.value {
+                valueText = String(format: "%.2f", val)
+            }
+        }
     }
 }

--- a/binthere/Views/Items/BulkValuationSheet.swift
+++ b/binthere/Views/Items/BulkValuationSheet.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+import SwiftData
+
+struct BulkValuationSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    let title: String
+    let items: [Item]
+
+    @State private var analysisService = ImageAnalysisService()
+    @State private var phase: Phase = .review
+    @State private var estimates: [UUID: ImageAnalysisService.BulkValueResult] = [:]
+    @State private var acceptedIds: Set<UUID> = []
+    @State private var task: Task<Void, Never>?
+
+    enum Phase {
+        case review     // pre-estimate: show items, "Estimate" button
+        case estimating
+        case results    // show estimates, allow accept/reject per item
+        case done
+    }
+
+    private var itemsWithoutValue: [Item] {
+        items.filter { $0.value == nil }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .review:
+                    reviewView
+                case .estimating:
+                    estimatingView
+                case .results:
+                    resultsView
+                case .done:
+                    doneView
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        task?.cancel()
+                        dismiss()
+                    }
+                }
+                if phase == .results {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") { applyAccepted() }
+                            .disabled(acceptedIds.isEmpty)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Phases
+
+    private var reviewView: some View {
+        VStack(spacing: 0) {
+            List {
+                Section {
+                    Text(
+                        "AI will estimate the resale value for the items below in a single batch. " +
+                        "You'll review and accept each estimate before it's saved."
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                }
+
+                Section("Items (\(itemsWithoutValue.count))") {
+                    if itemsWithoutValue.isEmpty {
+                        Text("All items already have values set. Cancel to dismiss, or run anyway to overwrite.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        ForEach(items) { item in
+                            HStack {
+                                Text(item.name)
+                                Spacer()
+                                Text(CurrencyFormatter.format(item.value))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    } else {
+                        ForEach(itemsWithoutValue) { item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.name)
+                                if !item.itemDescription.isEmpty {
+                                    Text(item.itemDescription)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Button(action: startEstimation) {
+                Label("Estimate Values with AI", systemImage: "sparkles")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, minHeight: 24)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+        }
+    }
+
+    private var estimatingView: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("Estimating values...")
+                .font(.headline)
+            Text("AI is reviewing \(itemsToEstimate().count) items")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+
+            Button("Cancel") {
+                task?.cancel()
+                phase = .review
+            }
+            .buttonStyle(.bordered)
+            .padding(.bottom, 32)
+        }
+    }
+
+    private var resultsView: some View {
+        Group {
+            if let error = analysisService.error {
+                ContentUnavailableView(
+                    "Estimation Failed",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(error.localizedDescription)
+                )
+            } else if estimates.isEmpty {
+                ContentUnavailableView(
+                    "No Estimates",
+                    systemImage: "questionmark.circle",
+                    description: Text("AI didn't return any estimates.")
+                )
+            } else {
+                List {
+                    Section {
+                        Text("Tap items to toggle. Saved values use \"AI\" as the source.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ForEach(itemsToEstimate()) { item in
+                        if let estimate = estimates[item.id] {
+                            estimateRow(item: item, estimate: estimate)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var doneView: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 60))
+                .foregroundStyle(.green)
+            Text("Values Saved")
+                .font(.title2.bold())
+            Text("\(acceptedIds.count) item\(acceptedIds.count == 1 ? "" : "s") updated")
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("Done") { dismiss() }
+                .buttonStyle(.borderedProminent)
+                .padding(.bottom, 32)
+        }
+    }
+
+    private func estimateRow(item: Item, estimate: ImageAnalysisService.BulkValueResult) -> some View {
+        Button(action: { toggle(item.id) }) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: acceptedIds.contains(item.id) ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(acceptedIds.contains(item.id) ? Color.green : .secondary)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(item.name)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(CurrencyFormatter.format(estimate.value))
+                            .font(.headline)
+                            .foregroundStyle(.green)
+                    }
+                    if !estimate.reasoning.isEmpty {
+                        Text(estimate.reasoning)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Actions
+
+    private func itemsToEstimate() -> [Item] {
+        itemsWithoutValue.isEmpty ? items : itemsWithoutValue
+    }
+
+    private func toggle(_ id: UUID) {
+        if acceptedIds.contains(id) {
+            acceptedIds.remove(id)
+        } else {
+            acceptedIds.insert(id)
+        }
+    }
+
+    private func startEstimation() {
+        let targets = itemsToEstimate()
+        let inputs = targets.map {
+            ImageAnalysisService.BulkValueInput(
+                id: $0.id,
+                name: $0.name,
+                description: $0.itemDescription
+            )
+        }
+        phase = .estimating
+        task = Task {
+            let results = await analysisService.estimateValuesBulk(items: inputs)
+            await MainActor.run {
+                estimates = results
+                acceptedIds = Set(results.keys)
+                phase = .results
+            }
+        }
+    }
+
+    private func applyAccepted() {
+        for item in itemsToEstimate() {
+            guard acceptedIds.contains(item.id),
+                  let estimate = estimates[item.id] else { continue }
+            item.value = estimate.value
+            item.valueSource = "ai"
+            item.valueUpdatedAt = Date()
+            item.updatedAt = Date()
+        }
+        try? modelContext.save()
+        phase = .done
+    }
+}

--- a/binthere/Views/Settings/ZoneDetailView.swift
+++ b/binthere/Views/Settings/ZoneDetailView.swift
@@ -8,6 +8,11 @@ struct ZoneDetailView: View {
 
     @State private var showingDeleteConfirmation = false
     @State private var showingAddBin = false
+    @State private var showingBulkValuation = false
+
+    private var allItemsInZone: [Item] {
+        zone.bins.flatMap(\.items)
+    }
 
     var body: some View {
         List {
@@ -84,12 +89,27 @@ struct ZoneDetailView: View {
             BinDetailView(bin: bin)
         }
         .toolbar {
-            Button(action: { showingAddBin = true }) {
-                Label("Add Bin", systemImage: "plus")
+            Menu {
+                Button(action: { showingAddBin = true }) {
+                    Label("Add Bin", systemImage: "plus")
+                }
+                Button(action: { showingBulkValuation = true }) {
+                    Label("Estimate Values with AI", systemImage: "sparkles")
+                }
+                .disabled(allItemsInZone.isEmpty)
+            } label: {
+                Label("More", systemImage: "ellipsis.circle")
             }
         }
         .sheet(isPresented: $showingAddBin) {
             AddBinToZoneSheet(zone: zone)
+        }
+        .sheet(isPresented: $showingBulkValuation) {
+            BulkValuationSheet(
+                title: "Estimate Values: \(zone.name)",
+                items: allItemsInZone
+            )
+            .cardPresentation()
         }
         .alert("Delete Zone?", isPresented: $showingDeleteConfirmation) {
             Button("Delete", role: .destructive) {


### PR DESCRIPTION
## Summary

Three Phase 12 items knocked out before App Store launch.

**UI fixes:**
- Color picker no longer cut off — wrapped in horizontal ScrollView with proper padding
- Icon picker is now collapsible by group with chevron toggles. Auto-expands the group containing the currently selected icon. Saves a ton of vertical space in zone forms.

**AI inline editing:**
- SuggestedItem now carries `color`, `value`, and a `tagsText` accessor
- Each AI suggestion row has a chevron that expands per-row controls for tags, color (full ColorPickerRow), and currency value
- Users can edit all fields on every suggestion before saving the batch — no longer just save/dont-save toggles
- Saved items persist color, value (with `valueSource = "ai"`), householdId, and updatedAt

**Bulk AI value estimation:**
- New `ImageAnalysisService.estimateValuesBulk` — takes a list of items and asks Claude for estimates in a single API call
- New `BulkValuationSheet` with 4 phases: review → estimating → results → done
- Cancel button aborts the running task
- Results phase shows estimate + reasoning per item with toggleable accept/reject
- Available from BinDetailView overflow menu (estimate all items in the bin)
- Available from ZoneDetailView toolbar menu (estimate all items across all bins in the zone)

## Test plan

- [ ] Color picker scrolls horizontally, no clipping
- [ ] Icon picker groups collapse/expand with chevron
- [ ] AI analyze a bin photo → tap chevron on suggestion → edit color/tags/value inline → save → verify item has all fields
- [ ] Bin detail → More → Estimate Values with AI → review → estimate → toggle some off → save → verify values applied
- [ ] Zone detail → menu → Estimate Values with AI → all items across bins → save
- [ ] Build, lint pass