### PR TITLE
feat: full account deletion + App Store listing copy

### DIFF
--- a/binthere/Services/AuthService.swift
+++ b/binthere/Services/AuthService.swift
@@ -149,31 +149,17 @@ final class AuthService {
     // MARK: - Delete Account
 
     func deleteAccount() async throws {
-        guard let userId = currentUserId else { return }
+        guard currentUserId != nil else { return }
 
-        // Delete all user data from Supabase tables via RPC or direct deletes
-        // Household memberships, then the user's auth account
-        try await client.from("household_members")
-            .delete()
-            .eq("user_id", value: userId)
-            .execute()
+        // Calls the SECURITY DEFINER RPC defined in
+        // supabase/migrations/004_delete_account.sql, which removes the
+        // user from any shared households, drops households where they
+        // were the only member (cascading zones/bins/items), and finally
+        // deletes the auth.users row.
+        try await client.rpc("delete_user_account").execute()
 
-        // Delete households where user is the sole owner
-        let ownedHouseholds = try await client.from("household_members")
-            .select("household_id")
-            .eq("user_id", value: userId)
-            .eq("role", value: "owner")
-            .execute()
-
-        // Sign out and clear local state
-        try await client.auth.signOut()
+        try? await client.auth.signOut()
         currentUserId = nil
         currentEmail = nil
-
-        // Note: Supabase admin API is needed to fully delete the auth user.
-        // For now, the user's data is removed and they're signed out.
-        // Set up a Supabase Edge Function or database trigger to cascade-delete
-        // the auth.users record when all memberships are removed.
-        _ = ownedHouseholds
     }
 }

--- a/binthere/Views/Settings/SettingsView.swift
+++ b/binthere/Views/Settings/SettingsView.swift
@@ -1,7 +1,9 @@
+import SwiftData
 import SwiftUI
 import UserNotifications
 
 struct SettingsView: View {
+    @Environment(\.modelContext) private var modelContext
     @Environment(AuthService.self) private var authService
     @Environment(HouseholdService.self) private var householdService
     @Environment(SyncService.self) private var syncService
@@ -171,6 +173,7 @@ struct SettingsView: View {
                 Task {
                     do {
                         try await authService.deleteAccount()
+                        wipeLocalData()
                     } catch {
                         deleteError = error.localizedDescription
                     }
@@ -180,6 +183,15 @@ struct SettingsView: View {
         } message: {
             Text("This will permanently delete your account, all your bins, items, and data. This action cannot be undone.")
         }
+    }
+
+    private func wipeLocalData() {
+        try? modelContext.delete(model: CustomAttribute.self)
+        try? modelContext.delete(model: CheckoutRecord.self)
+        try? modelContext.delete(model: Item.self)
+        try? modelContext.delete(model: Bin.self)
+        try? modelContext.delete(model: Zone.self)
+        try? modelContext.save()
     }
 
     private func syncNow() {

--- a/docs/app-store-listing.md
+++ b/docs/app-store-listing.md
@@ -1,0 +1,230 @@
+# App Store Connect Listing — binthere
+
+Copy-paste fields for App Store Connect submission. Update version-specific
+fields ("What's New") for each release.
+
+---
+
+## App Name (30 chars max)
+
+binthere
+
+## Subtitle (30 chars max)
+
+Never lose your stuff again
+
+## Promotional Text (170 chars max, can be updated without resubmission)
+
+Snap a photo and let AI catalog your bins, drawers, and storage. Scan a QR code to instantly see what's inside. Stop digging — start finding.
+
+## Description (4000 chars max)
+
+Where the heck did you put it?
+
+binthere is a beautifully simple way to keep track of every physical thing you own — the holiday decorations in the attic, the cables in the junk drawer, the tools in the garage, the kid's outgrown clothes in the basement.
+
+Snap a photo of a bin's contents, and AI does the rest. It identifies each item, names it, describes it, tags it, and even estimates what it's worth. You review, edit, and save — no tedious typing.
+
+Each bin gets a printable QR code label. Stick it on the box. Scan it later and you instantly see everything inside, right on your phone.
+
+KEY FEATURES
+
+• AI-powered cataloging — point your camera at a bin, get a complete inventory in seconds
+• QR code labels — generate, print, scan. No more guessing what's in the box.
+• Zones — group bins by room, garage, attic, storage unit, anywhere
+• Check items in and out — borrow a tool, lend a book, track who has what
+• Bulk value estimation — let AI estimate the total value of a bin or zone for insurance, moves, or downsizing
+• Tags, colors, custom fields — organize the way that makes sense to you
+• Search across everything — find any item across every bin in seconds
+• Share with your household — partners and roommates see the same inventory in real time
+• Reports & analytics — total value, item counts, what's overdue to come back
+• Photos for every item — visual confirmation, not just words
+• Works offline — your inventory is on your device first, synced second
+• Privacy-first — your data is yours. No ads. No tracking. No selling.
+
+PERFECT FOR
+
+• Anyone with a garage, basement, attic, or storage unit
+• Families managing seasonal stuff (holiday, sports, hobbies)
+• Hobbyists with parts, tools, supplies, and components
+• People preparing for a move
+• Estate organization and downsizing
+• Insurance documentation
+• Renters tracking what's in storage
+
+WHY BINTHERE?
+
+Because "I know I have one of those somewhere" is the most expensive sentence in your house. You buy duplicates. You waste hours digging. You forget what you own. binthere fixes that — once.
+
+Set it up over a weekend with the AI scan, and from then on every container is a tap away.
+
+PRIVACY
+
+binthere stores your inventory securely in your account. We don't sell your data, show you ads, or track you. Photos you take are stored in your account so you can access them across your devices. AI analysis is done on-demand and never used to train external models. Read the full privacy policy at [your privacy URL].
+
+Built by one developer who got tired of saying "where the f—— is that thing?" Welcome to never losing it again.
+
+## Keywords (100 chars max, comma separated, no spaces)
+
+inventory,storage,organize,QR,bins,home,declutter,catalog,moving,attic,garage,closet,stuff,items
+
+## Support URL
+
+https://patrickisgreat.github.io/binthere/
+
+## Marketing URL (optional)
+
+https://patrickisgreat.github.io/binthere/
+
+## Privacy Policy URL
+
+https://patrickisgreat.github.io/binthere/privacy.html
+
+## Category
+
+Primary: Productivity
+Secondary: Lifestyle
+
+## Age Rating
+
+4+
+
+## Copyright
+
+© 2026 Patrick Bennett
+
+---
+
+## What's New (4000 chars max, per release)
+
+### 1.0.0
+
+Welcome to binthere! The first release.
+
+• AI-powered bin cataloging — snap a photo, get every item identified, named, tagged, and valued
+• QR code labels for every bin
+• Zones to group bins by location
+• Check items in and out
+• Household sharing — sync your inventory with partners and roommates
+• Reports and analytics — total value, item counts, search across everything
+• Sign in with Apple, Google, or email
+• Offline-first with cloud sync
+
+---
+
+## App Review Information
+
+### Demo Account
+
+Email: [your test account email in Supabase]
+Password: [your test account password]
+
+NOTE: this account is pre-confirmed — no email verification step needed.
+
+### Notes for Reviewer
+
+binthere is a personal inventory app. To exercise the full flow:
+
+1. Sign in with the demo account above
+2. The account has a pre-populated household with one zone, one bin, and a few items
+3. Tap the bin to see its contents
+4. Try the AI scan feature: tap the camera button on a bin, take a photo of any objects, and the app will identify and catalog them
+   • AI features require an Anthropic API key. The demo account has one configured in Settings.
+5. Print or display the QR code on a bin and scan it from the Scan tab to verify QR routing
+
+The Sign in with Apple flow uses Supabase as the backend.
+
+Account deletion fully removes the user's auth record, household memberships, and all owned data — confirmed via the Delete Account button in Settings.
+
+### Contact Info
+
+First Name: Patrick
+Last Name: Bennett
+Phone: [your phone]
+Email: patrickisgreat@gmail.com
+
+---
+
+## Privacy "Nutrition Label" Questionnaire
+
+Apple asks what data your app collects, whether it's linked to the user's identity, and whether it's used for tracking. Answer in App Store Connect → App Privacy.
+
+### Data Collected
+
+**Contact Info → Email Address**
+- Linked to user: YES
+- Used for tracking: NO
+- Purposes: App Functionality (account login)
+
+**User Content → Photos**
+- Linked to user: YES
+- Used for tracking: NO
+- Purposes: App Functionality (storing item photos in their inventory)
+
+**User Content → Other User Content** (item names, descriptions, tags, values)
+- Linked to user: YES
+- Used for tracking: NO
+- Purposes: App Functionality
+
+**Identifiers → User ID** (Supabase auth UUID)
+- Linked to user: YES
+- Used for tracking: NO
+- Purposes: App Functionality
+
+### Data NOT Collected
+
+- Location (no GPS or IP location)
+- Contacts
+- Health & Fitness
+- Financial Info (item values are user-entered estimates, not real financial data)
+- Browsing History
+- Search History
+- Device ID for tracking
+- Advertising Data
+- Diagnostic Data sent to third parties
+
+### Tracking
+
+NO. binthere does not track users across apps or websites owned by other companies. There is no advertising SDK, no analytics SDK that does cross-app tracking, and no data is shared with data brokers.
+
+### Third-Party Data Use
+
+- **Supabase**: hosts the database and auth. Bound by Supabase's DPA. Data is in your project, not pooled.
+- **Anthropic API (Claude)**: when the user invokes AI scan, the photo and a prompt are sent to Anthropic for one-shot inference. Anthropic does not train on API data. Photos are not retained beyond the request lifecycle.
+- **Apple Push Notification Service**: standard APNs for reminders.
+
+---
+
+## Export Compliance
+
+ITSAppUsesNonExemptEncryption: NO
+
+binthere uses only standard HTTPS and Apple-provided cryptography. No proprietary encryption.
+
+---
+
+## Screenshots
+
+Located in `screens/`:
+
+- 01-household-setup.png
+- 02-bins-list.png
+- 03-bins-menu.png
+- 04-bin-empty.png
+- 05-bin-items.png
+- 06-set-value.png
+- 07-item-detail.png
+- 08-zones-grid.png
+- 09-zone-detail.png
+- 10-zone-settings.png
+- 11-qr-label.png
+- 12-settings.png
+- 13-settings-detail.png
+- 14-reports.png
+- 15-analytics.png
+- 16-analytics-charts.png
+
+Apple required sizes:
+- 6.7" iPhone (iPhone 17 Pro Max / 16 Pro Max): 1290 × 2796 px — REQUIRED
+- 6.5" iPhone (older Plus/Max models): 1242 × 2688 px — recommended
+- iPad Pro 13": 2064 × 2752 px — only if iPad is supported

--- a/supabase/migrations/004_delete_account.sql
+++ b/supabase/migrations/004_delete_account.sql
@@ -1,0 +1,63 @@
+-- 004_delete_account.sql
+-- Full account deletion. Apple App Store policy requires that any app
+-- offering account creation also offer in-app account deletion that
+-- fully removes the user's account and personal data — not just sign out.
+--
+-- This RPC runs as SECURITY DEFINER so it can delete the auth.users row,
+-- which a regular client role cannot do. It only ever operates on the
+-- caller (auth.uid()), so there's no privilege escalation risk.
+
+CREATE OR REPLACE FUNCTION public.delete_user_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+    uid UUID := auth.uid();
+    household_record RECORD;
+    remaining_members INTEGER;
+BEGIN
+    IF uid IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+
+    -- For each household the user belongs to, decide whether to drop the
+    -- whole household (if the user was the sole remaining member) or
+    -- just remove their membership.
+    FOR household_record IN
+        SELECT household_id
+        FROM household_members
+        WHERE user_id = uid
+    LOOP
+        SELECT COUNT(*) INTO remaining_members
+        FROM household_members
+        WHERE household_id = household_record.household_id
+          AND user_id <> uid;
+
+        IF remaining_members = 0 THEN
+            -- Sole member: delete the household. ON DELETE CASCADE on
+            -- household_id columns will clean up zones, bins, items,
+            -- checkout_records, custom_attributes, invitations, and the
+            -- household_members row itself.
+            DELETE FROM households WHERE id = household_record.household_id;
+        ELSE
+            -- Other members remain: just remove this user's membership.
+            DELETE FROM household_members
+            WHERE household_id = household_record.household_id
+              AND user_id = uid;
+        END IF;
+    END LOOP;
+
+    -- Null out audit pointers on records that survive (other members'
+    -- households where this user created bins/items/checkouts).
+    UPDATE items SET created_by = NULL WHERE created_by = uid;
+    UPDATE checkout_records SET checked_out_by = NULL WHERE checked_out_by = uid;
+
+    -- Finally, delete the auth user. This invalidates all their sessions.
+    DELETE FROM auth.users WHERE id = uid;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.delete_user_account() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.delete_user_account() TO authenticated;


### PR DESCRIPTION
## Summary
- Adds a SECURITY DEFINER Postgres RPC (\`delete_user_account\`) that fully removes a user: shared-household memberships, sole-owner households (cascading zones/bins/items/checkouts), nulled audit pointers, and the \`auth.users\` row itself.
- \`AuthService.deleteAccount\` now calls the RPC and wipes local SwiftData so the next sign-in starts clean.
- Adds [docs/app-store-listing.md](docs/app-store-listing.md) with description, keywords, privacy nutrition label answers, reviewer notes, and screenshot list — copy-paste ready for App Store Connect.

## Why
Apple App Store guideline 5.1.1(v) requires apps that let users create accounts to also let them fully delete those accounts in-app. The old implementation only removed \`household_members\` rows and signed the user out — \`auth.users\` plus any data in sole-member households was orphaned. This is a likely rejection trigger.

## Test plan
- [ ] Apply migration \`004_delete_account.sql\` to Supabase (Dashboard → SQL editor, or \`supabase db push\`)
- [ ] Sign in as a fresh test user, create a household, add a zone/bin/item
- [ ] Tap Settings → Delete Account → Delete Everything
- [ ] Verify in Supabase Dashboard: \`auth.users\` row is gone, \`households\` / \`zones\` / \`bins\` / \`items\` rows are gone
- [ ] Verify the app returns to the sign-in screen with no leftover local data
- [ ] Repeat with a user who is a non-owner member of a shared household — verify only their membership is removed and the household survives