### PR TITLE
fix: per-user API key storage + lowercase UUIDs for sync RLS

### DIFF
--- a/binthere/Services/AuthService.swift
+++ b/binthere/Services/AuthService.swift
@@ -25,12 +25,15 @@ final class AuthService {
                     switch event {
                     case .signedIn, .tokenRefreshed, .initialSession:
                         if let session {
-                            self.currentUserId = session.user.id.uuidString.lowercased()
+                            let userId = session.user.id.uuidString.lowercased()
+                            self.currentUserId = userId
                             self.currentEmail = session.user.email
+                            ImageAnalysisService.setCurrentUser(userId)
                         }
                     case .signedOut:
                         self.currentUserId = nil
                         self.currentEmail = nil
+                        ImageAnalysisService.setCurrentUser(nil)
                     default:
                         break
                     }
@@ -55,8 +58,10 @@ final class AuthService {
                 group.cancelAll()
                 return result
             }
-            currentUserId = session.user.id.uuidString.lowercased()
+            let userId = session.user.id.uuidString.lowercased()
+            currentUserId = userId
             currentEmail = session.user.email
+            ImageAnalysisService.setCurrentUser(userId)
         } catch {
             currentUserId = nil
             currentEmail = nil

--- a/binthere/Services/HouseholdService.swift
+++ b/binthere/Services/HouseholdService.swift
@@ -59,7 +59,7 @@ final class HouseholdService {
     private var client: SupabaseClient { SupabaseManager.shared.client }
 
     var currentHouseholdId: String {
-        currentHousehold?.id.uuidString ?? ""
+        currentHousehold?.id.uuidString.lowercased() ?? ""
     }
 
     // MARK: - Load Current Household
@@ -86,7 +86,7 @@ final class HouseholdService {
             // Fetch the household
             let households: [Household] = try await client.from("households")
                 .select()
-                .eq("id", value: membership.householdId.uuidString)
+                .eq("id", value: membership.householdId.uuidString.lowercased())
                 .execute()
                 .value
 
@@ -110,18 +110,16 @@ final class HouseholdService {
 
             // Create household — created_by defaults to auth.uid() via DB default
             let householdPayload: [String: AnyJSON] = [
-                "id": .string(householdId.uuidString),
+                "id": .string(householdId.uuidString.lowercased()),
                 "name": .string(name),
                 "created_by": .string(userId),
             ]
 
-            // Use rpc or direct insert. The RLS policy checks auth.uid() = created_by,
-            // so the userId must exactly match what auth.uid() returns (lowercase UUID).
             try await client.from("households").insert(householdPayload).execute()
 
             // Add creator as owner
             let memberPayload: [String: AnyJSON] = [
-                "household_id": .string(householdId.uuidString),
+                "household_id": .string(householdId.uuidString.lowercased()),
                 "user_id": .string(userId),
                 "role": .string("owner"),
                 "display_name": .string(displayName),

--- a/binthere/Services/ImageAnalysisService.swift
+++ b/binthere/Services/ImageAnalysisService.swift
@@ -58,11 +58,20 @@ final class ImageAnalysisService {
     If you cannot identify items clearly, make your best guess. Return ONLY the JSON array, no other text.
     """
 
-    private static let apiKeyKey = "claude_api_key"
+    private static var currentUserId: String?
+
+    static func setCurrentUser(_ userId: String?) {
+        currentUserId = userId
+    }
+
+    private static var apiKeyKey: String {
+        guard let userId = currentUserId else { return "claude_api_key" }
+        return "claude_api_key_\(userId)"
+    }
 
     static var apiKey: String? {
-        get { UserDefaults.standard.string(forKey: Self.apiKeyKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Self.apiKeyKey) }
+        get { UserDefaults.standard.string(forKey: apiKeyKey) }
+        set { UserDefaults.standard.set(newValue, forKey: apiKeyKey) }
     }
 
     func analyzeImage(_ image: UIImage) async {

--- a/binthere/Services/SyncService.swift
+++ b/binthere/Services/SyncService.swift
@@ -188,7 +188,7 @@ final class SyncService {
 
     func pushZone(_ zone: Zone, householdId: String) async throws {
         let payload: [String: AnyJSON] = [
-            "id": .string(zone.id.uuidString),
+            "id": .string(zone.id.uuidString.lowercased()),
             "household_id": .string(householdId),
             "name": .string(zone.name),
             "location_description": .string(zone.locationDescription),
@@ -201,7 +201,7 @@ final class SyncService {
 
     func pushBin(_ bin: Bin, householdId: String) async throws {
         var payload: [String: AnyJSON] = [
-            "id": .string(bin.id.uuidString),
+            "id": .string(bin.id.uuidString.lowercased()),
             "household_id": .string(householdId),
             "code": .string(bin.code),
             "name": .string(bin.name),
@@ -210,7 +210,7 @@ final class SyncService {
             "color": .string(bin.color),
         ]
         if let zoneId = bin.zone?.id {
-            payload["zone_id"] = .string(zoneId.uuidString)
+            payload["zone_id"] = .string(zoneId.uuidString.lowercased())
         }
         try await client.from("bins").upsert(payload).execute()
         bin.updatedAt = Date()
@@ -218,7 +218,7 @@ final class SyncService {
 
     func pushItem(_ item: Item, householdId: String) async throws {
         var payload: [String: AnyJSON] = [
-            "id": .string(item.id.uuidString),
+            "id": .string(item.id.uuidString.lowercased()),
             "household_id": .string(householdId),
             "name": .string(item.name),
             "item_description": .string(item.itemDescription),
@@ -233,7 +233,7 @@ final class SyncService {
             "allowed_checkout_users": .array(item.allowedCheckoutUsers.map { .string($0) }),
         ]
         if let binId = item.bin?.id {
-            payload["bin_id"] = .string(binId.uuidString)
+            payload["bin_id"] = .string(binId.uuidString.lowercased())
         }
         if let value = item.value {
             payload["value"] = .double(value)
@@ -247,14 +247,14 @@ final class SyncService {
 
     func pushCheckoutRecord(_ record: CheckoutRecord, householdId: String) async throws {
         var payload: [String: AnyJSON] = [
-            "id": .string(record.id.uuidString),
+            "id": .string(record.id.uuidString.lowercased()),
             "household_id": .string(householdId),
             "checked_out_to": .string(record.checkedOutTo),
             "checked_out_by": .string(record.checkedOutBy),
             "notes": .string(record.notes),
         ]
         if let itemId = record.item?.id {
-            payload["item_id"] = .string(itemId.uuidString)
+            payload["item_id"] = .string(itemId.uuidString.lowercased())
         }
         if let checkedInAt = record.checkedInAt {
             payload["checked_in_at"] = .string(ISO8601DateFormatter().string(from: checkedInAt))
@@ -464,15 +464,15 @@ final class SyncService {
     // MARK: - Delete
 
     func deleteRemoteZone(_ id: UUID) async throws {
-        try await client.from("zones").delete().eq("id", value: id.uuidString).execute()
+        try await client.from("zones").delete().eq("id", value: id.uuidString.lowercased()).execute()
     }
 
     func deleteRemoteBin(_ id: UUID) async throws {
-        try await client.from("bins").delete().eq("id", value: id.uuidString).execute()
+        try await client.from("bins").delete().eq("id", value: id.uuidString.lowercased()).execute()
     }
 
     func deleteRemoteItem(_ id: UUID) async throws {
-        try await client.from("items").delete().eq("id", value: id.uuidString).execute()
+        try await client.from("items").delete().eq("id", value: id.uuidString.lowercased()).execute()
     }
 }
 


### PR DESCRIPTION
## Summary
- **API key per-user** — \`ImageAnalysisService.apiKey\` was stored device-globally in UserDefaults. If User A entered a key and signed out, User B on the same device would see it. Now namespaced per user ID (\`claude_api_key_{userId}\`). Cleared on sign-out via \`setCurrentUser(nil)\`.
- **Lowercase UUIDs** — all UUID strings sent to Supabase (push, delete, household creation, household lookup) are now \`.lowercased()\`. Swift's \`UUID.uuidString\` returns uppercase, but Postgres \`auth.uid()\` returns lowercase. The mismatch caused RLS violations on bins/items/zones during sync push.

## Test plan
- [ ] Sign in, set an API key in Settings, sign out
- [ ] Sign in as a different user — API key field should be empty
- [ ] Sign back in as original user — API key should reappear
- [ ] Create a zone, bin, and item — verify sync completes without RLS errors
- [ ] Tap "Sync Now" in Settings — no errors
- [ ] Check Supabase tables — all UUIDs should be lowercase