### PR TITLE
feat: add Checked Out tab + improve checkout flow

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -58,12 +58,12 @@
 		CC00000100000002AAAAAA01 /* ZoneDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000002BBBBBB01 /* ZoneDetailView.swift */; };
 		CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000003BBBBBB01 /* HomeKitService.swift */; };
 		CC00000100000004AAAAAA01 /* ZonesGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000004BBBBBB01 /* ZonesGridView.swift */; };
-
 		EE00000100000001AAAAAA01 /* CustomAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000001BBBBBB01 /* CustomAttribute.swift */; };
 		EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */; };
 		EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000003BBBBBB01 /* SetValueSheet.swift */; };
 		EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */; };
 		EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */; };
+		GG00000100000001AAAAAA01 /* CheckedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GG00000100000001BBBBBB01 /* CheckedOutView.swift */; };
 		FF00000100000001AAAAAA01 /* ReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000001BBBBBB01 /* ReportService.swift */; };
 		FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */; };
 		FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000003BBBBBB01 /* ReportsView.swift */; };
@@ -141,13 +141,13 @@
 		CC00000100000002BBBBBB01 /* ZoneDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneDetailView.swift; sourceTree = "<group>"; };
 		CC00000100000003BBBBBB01 /* HomeKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeKitService.swift; sourceTree = "<group>"; };
 		CC00000100000004BBBBBB01 /* ZonesGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZonesGridView.swift; sourceTree = "<group>"; };
-
 		DD00000100000002BBBBBB01 /* binthere.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = binthere.entitlements; sourceTree = "<group>"; };
 		EE00000100000001BBBBBB01 /* CustomAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAttribute.swift; sourceTree = "<group>"; };
 		EE00000100000002BBBBBB01 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		EE00000100000003BBBBBB01 /* SetValueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetValueSheet.swift; sourceTree = "<group>"; };
 		EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributeSheet.swift; sourceTree = "<group>"; };
 		EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkValuationSheet.swift; sourceTree = "<group>"; };
+		GG00000100000001BBBBBB01 /* CheckedOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckedOutView.swift; sourceTree = "<group>"; };
 		FF00000100000001BBBBBB01 /* ReportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportService.swift; sourceTree = "<group>"; };
 		FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDashboardView.swift; sourceTree = "<group>"; };
 		FF00000100000003BBBBBB01 /* ReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportsView.swift; sourceTree = "<group>"; };
@@ -278,7 +278,6 @@
 				AA00000100000010BBBBBB01 /* QRGeneratorService.swift */,
 				AA00000100000011BBBBBB01 /* ImageAnalysisService.swift */,
 				CC00000100000003BBBBBB01 /* HomeKitService.swift */,
-
 				FF00000100000001BBBBBB01 /* ReportService.swift */,
 				AB00000100000001BBBBBB01 /* SupabaseClient.swift */,
 				AB00000100000002BBBBBB01 /* AuthService.swift */,
@@ -310,6 +309,7 @@
 				EE00000100000003BBBBBB01 /* SetValueSheet.swift */,
 				EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */,
 				EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */,
+				GG00000100000001BBBBBB01 /* CheckedOutView.swift */,
 				AB0000010000000EBBBBBB01 /* RequestItemSheet.swift */,
 			);
 			path = Items;
@@ -548,12 +548,12 @@
 				CC00000100000002AAAAAA01 /* ZoneDetailView.swift in Sources */,
 				CC00000100000003AAAAAA01 /* HomeKitService.swift in Sources */,
 				CC00000100000004AAAAAA01 /* ZonesGridView.swift in Sources */,
-
 				EE00000100000001AAAAAA01 /* CustomAttribute.swift in Sources */,
 				EE00000100000002AAAAAA01 /* CurrencyFormatter.swift in Sources */,
 				EE00000100000003AAAAAA01 /* SetValueSheet.swift in Sources */,
 				EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */,
 				EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */,
+				GG00000100000001AAAAAA01 /* CheckedOutView.swift in Sources */,
 				FF00000100000001AAAAAA01 /* ReportService.swift in Sources */,
 				FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */,
 				FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */,
@@ -749,7 +749,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = binthere/Info.plist;
-
 				INFOPLIST_KEY_NSCameraUsageDescription = "binthere needs camera access to scan QR codes and take photos of items.";
 				INFOPLIST_KEY_NSHomeKitUsageDescription = "binthere can import room names from HomeKit to use as zones.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -761,7 +760,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = beeBetter.binthere;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPABASE_ANON_KEY = "$(SUPABASE_ANON_KEY)";
@@ -785,7 +784,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = binthere/Info.plist;
-
 				INFOPLIST_KEY_NSCameraUsageDescription = "binthere needs camera access to scan QR codes and take photos of items.";
 				INFOPLIST_KEY_NSHomeKitUsageDescription = "binthere can import room names from HomeKit to use as zones.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -797,7 +795,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = beeBetter.binthere;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPABASE_ANON_KEY = "$(SUPABASE_ANON_KEY)";

--- a/binthere/Services/SyncService.swift
+++ b/binthere/Services/SyncService.swift
@@ -116,6 +116,13 @@ final class SyncService {
             try await pushItem(item, householdId: householdId)
             await CloudStorageService.syncItemImages(item: item, householdId: householdId)
         }
+
+        // Push checkout records created since last sync
+        let checkoutPredicate = #Predicate<CheckoutRecord> { $0.checkedOutAt > cutoff }
+        let dirtyCheckouts = try context.fetch(FetchDescriptor(predicate: checkoutPredicate))
+        for record in dirtyCheckouts {
+            try await pushCheckoutRecord(record, householdId: householdId)
+        }
     }
 
     // MARK: - Realtime Subscriptions

--- a/binthere/Views/Items/CheckedOutView.swift
+++ b/binthere/Views/Items/CheckedOutView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import SwiftData
+
+struct CheckedOutView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(filter: #Predicate<Item> { $0.isCheckedOut }, sort: \Item.updatedAt, order: .reverse)
+    private var checkedOutItems: [Item]
+
+    @State private var showingCheckoutItem: Item?
+
+    var body: some View {
+        Group {
+            if checkedOutItems.isEmpty {
+                ContentUnavailableView(
+                    "Nothing Checked Out",
+                    systemImage: "checkmark.circle",
+                    description: Text("All items are in their bins. Check out an item from a bin to track it here.")
+                )
+            } else {
+                List {
+                    Section {
+                        Text("\(checkedOutItems.count) item\(checkedOutItems.count == 1 ? "" : "s") currently out")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ForEach(overdueItems) { item in
+                        CheckedOutItemRow(item: item, isOverdue: true)
+                            .swipeActions(edge: .leading) {
+                                Button("Check In") { checkIn(item) }
+                                    .tint(.green)
+                            }
+                    }
+
+                    if !onTimeItems.isEmpty {
+                        Section(overdueItems.isEmpty ? "" : "On Time") {
+                            ForEach(onTimeItems) { item in
+                                CheckedOutItemRow(item: item, isOverdue: false)
+                                    .swipeActions(edge: .leading) {
+                                        Button("Check In") { checkIn(item) }
+                                            .tint(.green)
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Checked Out")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var overdueItems: [Item] {
+        checkedOutItems.filter { item in
+            guard let record = item.checkoutHistory.first(where: { $0.isActive }),
+                  let dueDate = record.expectedReturnDate else { return false }
+            return dueDate < Date()
+        }
+    }
+
+    private var onTimeItems: [Item] {
+        checkedOutItems.filter { item in
+            guard let record = item.checkoutHistory.first(where: { $0.isActive }) else { return true }
+            guard let dueDate = record.expectedReturnDate else { return true }
+            return dueDate >= Date()
+        }
+    }
+
+    private func checkIn(_ item: Item) {
+        if let record = item.checkoutHistory.first(where: { $0.isActive }) {
+            record.checkedInAt = Date()
+        }
+        item.isCheckedOut = false
+        item.updatedAt = Date()
+        NotificationService.cancelDueBackReminders(for: item.id)
+    }
+}
+
+private struct CheckedOutItemRow: View {
+    let item: Item
+    let isOverdue: Bool
+
+    private var activeRecord: CheckoutRecord? {
+        item.checkoutHistory.first(where: { $0.isActive })
+    }
+
+    var body: some View {
+        NavigationLink(value: item) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(item.name)
+                        .font(.headline)
+                    Spacer()
+                    if isOverdue {
+                        Text("OVERDUE")
+                            .font(.caption2.weight(.bold))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.red.opacity(0.2))
+                            .foregroundStyle(.red)
+                            .clipShape(Capsule())
+                    }
+                }
+
+                if let record = activeRecord {
+                    Label(record.checkedOutTo, systemImage: "person")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 12) {
+                        Label("Out \(record.checkedOutAt, style: .relative) ago",
+                              systemImage: "clock")
+                        if let dueDate = record.expectedReturnDate {
+                            Label("Due \(dueDate, style: .date)", systemImage: "calendar")
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(isOverdue ? .red : .secondary)
+                }
+
+                if let bin = item.bin {
+                    Label(bin.displayName, systemImage: "archivebox")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+}

--- a/binthere/Views/Items/ItemDetailView.swift
+++ b/binthere/Views/Items/ItemDetailView.swift
@@ -281,7 +281,7 @@ struct ItemDetailView: View {
 
     private var currentUserDisplayName: String {
         householdService.members
-            .first { $0.userId.uuidString == authService.currentUserId }?
+            .first { $0.userId.uuidString.lowercased() == authService.currentUserId }?
             .displayName ?? authService.currentEmail ?? ""
     }
 }
@@ -326,19 +326,40 @@ private struct CheckoutRecordRow: View {
 struct CheckoutSheet: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @Environment(HouseholdService.self) private var householdService
+    @Environment(AuthService.self) private var authService
     let item: Item
     var defaultName: String = ""
 
     @State private var checkedOutTo = ""
+    @State private var customName = ""
     @State private var notes = ""
     @State private var hasReturnDate = false
     @State private var expectedReturnDate = Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date()
+
+    private var resolvedName: String {
+        let name = checkedOutTo == "__custom__" ? customName : checkedOutTo
+        return name.trimmingCharacters(in: .whitespaces)
+    }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section("Who's taking it?") {
-                    TextField("Name", text: $checkedOutTo)
+                    if householdService.members.count > 1 {
+                        Picker("Person", selection: $checkedOutTo) {
+                            ForEach(householdService.members, id: \.id) { member in
+                                Text(member.displayName).tag(member.displayName)
+                            }
+                            Divider()
+                            Text("Someone else…").tag("__custom__")
+                        }
+                        if checkedOutTo == "__custom__" {
+                            TextField("Name", text: $customName)
+                        }
+                    } else {
+                        TextField("Name", text: $checkedOutTo)
+                    }
                 }
                 Section("Return Date") {
                     Toggle("Set return date", isOn: $hasReturnDate)
@@ -359,30 +380,33 @@ struct CheckoutSheet: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Check Out") { performCheckout() }
-                        .disabled(checkedOutTo.trimmingCharacters(in: .whitespaces).isEmpty)
+                        .disabled(resolvedName.isEmpty)
                 }
             }
             .onAppear {
-                if checkedOutTo.isEmpty && !defaultName.isEmpty {
+                if !defaultName.isEmpty {
                     checkedOutTo = defaultName
+                } else if let first = householdService.members.first?.displayName {
+                    checkedOutTo = first
                 }
             }
         }
     }
 
     private func performCheckout() {
-        let name = checkedOutTo.trimmingCharacters(in: .whitespaces)
+        let name = resolvedName
         let record = CheckoutRecord(
             item: item,
             checkedOutTo: name,
             expectedReturnDate: hasReturnDate ? expectedReturnDate : nil,
             notes: notes
         )
+        record.checkedOutBy = authService.currentUserId ?? ""
+        record.householdId = item.householdId
         modelContext.insert(record)
         item.isCheckedOut = true
         item.updatedAt = Date()
 
-        // Schedule due-back notifications
         if hasReturnDate {
             NotificationService.scheduleDueBackReminder(
                 itemId: item.id, itemName: item.name,

--- a/binthere/Views/MainTabView.swift
+++ b/binthere/Views/MainTabView.swift
@@ -24,12 +24,24 @@ struct MainTabView: View {
             .accessibilityIdentifier("zonesTab")
 
             NavigationStack {
+                CheckedOutView()
+                    .navigationDestination(for: Item.self) { item in
+                        ItemDetailView(item: item)
+                    }
+            }
+            .tabItem {
+                Label("Out", systemImage: "arrow.up.forward.circle")
+            }
+            .tag(2)
+            .accessibilityIdentifier("checkedOutTab")
+
+            NavigationStack {
                 ScannerTab()
             }
             .tabItem {
                 Label("Scan", systemImage: "qrcode.viewfinder")
             }
-            .tag(2)
+            .tag(3)
             .accessibilityIdentifier("scanTab")
 
             NavigationStack {
@@ -38,7 +50,7 @@ struct MainTabView: View {
             .tabItem {
                 Label("Reports", systemImage: "chart.bar")
             }
-            .tag(3)
+            .tag(4)
             .accessibilityIdentifier("reportsTab")
 
             NavigationStack {
@@ -47,7 +59,7 @@ struct MainTabView: View {
             .tabItem {
                 Label("Settings", systemImage: "gear")
             }
-            .tag(4)
+            .tag(5)
             .accessibilityIdentifier("settingsTab")
         }
     }


### PR DESCRIPTION
## Summary
- **New "Out" tab** — shows all checked-out items across every bin at a glance, grouped by overdue vs on-time. Swipe left to check in. Tap to navigate to item detail.
- **Household member picker** — checkout sheet now shows a picker of household members instead of a free-text name field. "Someone else…" option falls back to text input.
- **checkedOutBy tracking** — checkout records now store who initiated the checkout (current user ID)
- **Sync fix** — `pushAllDirty` now includes CheckoutRecords, which were previously never pushed to Supabase
- **UUID case fix** — `currentUserDisplayName` comparison now lowercases both sides

## Test plan
- [ ] New "Out" tab appears between Zones and Scan
- [ ] Empty state shows when nothing is checked out
- [ ] Check out an item from a bin → it appears in the Out tab
- [ ] Overdue items (past expected return date) show "OVERDUE" badge in red
- [ ] Swipe left on an item in Out tab → "Check In" action works
- [ ] Checkout sheet shows household member picker when >1 member
- [ ] "Someone else…" option in picker reveals free text field
- [ ] Sync Now in Settings pushes checkout records without errors