### PR TITLE
feat: global search with thumbnails and tag filtering

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */; };
 		EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */; };
 		GG00000100000001AAAAAA01 /* CheckedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GG00000100000001BBBBBB01 /* CheckedOutView.swift */; };
+		HH00000100000001AAAAAA01 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = HH00000100000001BBBBBB01 /* SearchView.swift */; };
 		FF00000100000001AAAAAA01 /* ReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000001BBBBBB01 /* ReportService.swift */; };
 		FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */; };
 		FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000003BBBBBB01 /* ReportsView.swift */; };
@@ -148,6 +149,7 @@
 		EE00000100000004BBBBBB01 /* EditAttributeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAttributeSheet.swift; sourceTree = "<group>"; };
 		EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkValuationSheet.swift; sourceTree = "<group>"; };
 		GG00000100000001BBBBBB01 /* CheckedOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckedOutView.swift; sourceTree = "<group>"; };
+		HH00000100000001BBBBBB01 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		FF00000100000001BBBBBB01 /* ReportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportService.swift; sourceTree = "<group>"; };
 		FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDashboardView.swift; sourceTree = "<group>"; };
 		FF00000100000003BBBBBB01 /* ReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportsView.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 				AA00000100000024CCCCCC01 /* Items */,
 				CC00000100000005CCCCCC01 /* Zones */,
 				FF00000100000004CCCCCC01 /* Reports */,
+				HH00000100000001CCCCCC01 /* Search */,
 				AA00000100000025CCCCCC01 /* Scanner */,
 				AA00000100000026CCCCCC01 /* Settings */,
 			);
@@ -313,6 +316,14 @@
 				AB0000010000000EBBBBBB01 /* RequestItemSheet.swift */,
 			);
 			path = Items;
+			sourceTree = "<group>";
+		};
+		HH00000100000001CCCCCC01 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				HH00000100000001BBBBBB01 /* SearchView.swift */,
+			);
+			path = Search;
 			sourceTree = "<group>";
 		};
 		AA00000100000025CCCCCC01 /* Scanner */ = {
@@ -554,6 +565,7 @@
 				EE00000100000004AAAAAA01 /* EditAttributeSheet.swift in Sources */,
 				EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */,
 				GG00000100000001AAAAAA01 /* CheckedOutView.swift in Sources */,
+				HH00000100000001AAAAAA01 /* SearchView.swift in Sources */,
 				FF00000100000001AAAAAA01 /* ReportService.swift in Sources */,
 				FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */,
 				FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */,

--- a/binthere/Views/MainTabView.swift
+++ b/binthere/Views/MainTabView.swift
@@ -6,12 +6,21 @@ struct MainTabView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             NavigationStack {
+                SearchView()
+            }
+            .tabItem {
+                Label("Search", systemImage: "magnifyingglass")
+            }
+            .tag(0)
+            .accessibilityIdentifier("searchTab")
+
+            NavigationStack {
                 BinListView()
             }
             .tabItem {
                 Label("Bins", systemImage: "archivebox")
             }
-            .tag(0)
+            .tag(1)
             .accessibilityIdentifier("binsTab")
 
             NavigationStack {
@@ -20,20 +29,8 @@ struct MainTabView: View {
             .tabItem {
                 Label("Zones", systemImage: "square.grid.2x2")
             }
-            .tag(1)
-            .accessibilityIdentifier("zonesTab")
-
-            NavigationStack {
-                CheckedOutView()
-                    .navigationDestination(for: Item.self) { item in
-                        ItemDetailView(item: item)
-                    }
-            }
-            .tabItem {
-                Label("Out", systemImage: "arrow.up.forward.circle")
-            }
             .tag(2)
-            .accessibilityIdentifier("checkedOutTab")
+            .accessibilityIdentifier("zonesTab")
 
             NavigationStack {
                 ScannerTab()
@@ -45,21 +42,12 @@ struct MainTabView: View {
             .accessibilityIdentifier("scanTab")
 
             NavigationStack {
-                ReportsView()
-            }
-            .tabItem {
-                Label("Reports", systemImage: "chart.bar")
-            }
-            .tag(4)
-            .accessibilityIdentifier("reportsTab")
-
-            NavigationStack {
                 SettingsView()
             }
             .tabItem {
                 Label("Settings", systemImage: "gear")
             }
-            .tag(5)
+            .tag(4)
             .accessibilityIdentifier("settingsTab")
         }
     }

--- a/binthere/Views/Search/SearchView.swift
+++ b/binthere/Views/Search/SearchView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+import SwiftData
+
+struct SearchView: View {
+    @Query(sort: \Item.name) private var allItems: [Item]
+    @Query(sort: \Bin.code) private var allBins: [Bin]
+
+    @State private var searchText = ""
+    @State private var selectedTags: Set<String> = []
+
+    private var checkedOutCount: Int {
+        allItems.filter(\.isCheckedOut).count
+    }
+
+    private var allTags: [String] {
+        let tags = Set(allItems.flatMap(\.tags))
+        return tags.sorted()
+    }
+
+    private var results: SearchResults {
+        let query = searchText.trimmingCharacters(in: .whitespaces)
+
+        var items = allItems
+        var bins = allBins
+
+        if !selectedTags.isEmpty {
+            items = items.filter { item in
+                !selectedTags.isDisjoint(with: item.tags)
+            }
+        }
+
+        if query.isEmpty {
+            return SearchResults(items: selectedTags.isEmpty ? [] : items, bins: [])
+        }
+
+        items = items.filter { item in
+            item.name.localizedCaseInsensitiveContains(query) ||
+            item.itemDescription.localizedCaseInsensitiveContains(query) ||
+            item.tags.contains { $0.localizedCaseInsensitiveContains(query) } ||
+            item.notes.localizedCaseInsensitiveContains(query) ||
+            item.color.localizedCaseInsensitiveContains(query)
+        }
+
+        bins = bins.filter { bin in
+            bin.code.localizedCaseInsensitiveContains(query) ||
+            bin.name.localizedCaseInsensitiveContains(query) ||
+            bin.location.localizedCaseInsensitiveContains(query) ||
+            bin.binDescription.localizedCaseInsensitiveContains(query)
+        }
+
+        return SearchResults(items: items, bins: bins)
+    }
+
+    var body: some View {
+        List {
+            if !allTags.isEmpty {
+                Section {
+                    tagFilterSection
+                }
+            }
+
+            if searchText.isEmpty && selectedTags.isEmpty {
+                if checkedOutCount > 0 {
+                    Section {
+                        NavigationLink {
+                            CheckedOutView()
+                                .navigationDestination(for: Item.self) { item in
+                                    ItemDetailView(item: item)
+                                }
+                        } label: {
+                            Label {
+                                HStack {
+                                    Text("Checked Out")
+                                    Spacer()
+                                    Text("\(checkedOutCount)")
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(.white)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 2)
+                                        .background(Theme.Colors.checkedOut)
+                                        .clipShape(Capsule())
+                                }
+                            } icon: {
+                                Image(systemName: "arrow.up.forward.circle")
+                                    .foregroundStyle(Theme.Colors.checkedOut)
+                            }
+                        }
+                    }
+                }
+
+                ContentUnavailableView(
+                    "Search Everything",
+                    systemImage: "magnifyingglass",
+                    description: Text("Find items, bins, and tags across your entire inventory.")
+                )
+            } else if results.isEmpty {
+                BrandedEmptyState.noSearchResults
+            } else {
+                if !results.items.isEmpty {
+                    Section("Items (\(results.items.count))") {
+                        ForEach(results.items) { item in
+                            NavigationLink(value: item) {
+                                SearchItemRow(item: item, query: searchText)
+                            }
+                        }
+                    }
+                }
+
+                if !results.bins.isEmpty {
+                    Section("Bins (\(results.bins.count))") {
+                        ForEach(results.bins) { bin in
+                            NavigationLink(value: bin) {
+                                SearchBinRow(bin: bin)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .searchable(text: $searchText, prompt: "Items, bins, tags…")
+        .navigationTitle("Search")
+        .navigationDestination(for: Item.self) { item in
+            ItemDetailView(item: item)
+        }
+        .navigationDestination(for: Bin.self) { bin in
+            BinDetailView(bin: bin)
+        }
+    }
+
+    private var tagFilterSection: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(allTags, id: \.self) { tag in
+                    Button {
+                        if selectedTags.contains(tag) {
+                            selectedTags.remove(tag)
+                        } else {
+                            selectedTags.insert(tag)
+                        }
+                    } label: {
+                        Text(tag)
+                            .font(.caption)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(selectedTags.contains(tag) ? Color.blue : Color.blue.opacity(0.1))
+                            .foregroundStyle(selectedTags.contains(tag) ? .white : .blue)
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if !selectedTags.isEmpty {
+                    Button {
+                        selectedTags.removeAll()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+    }
+}
+
+private struct SearchResults {
+    let items: [Item]
+    let bins: [Bin]
+
+    var isEmpty: Bool { items.isEmpty && bins.isEmpty }
+}
+
+private struct SearchItemRow: View {
+    let item: Item
+    let query: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let path = item.imagePaths.first,
+               let image = ImageStorageService.loadImage(filename: path) {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 48, height: 48)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(item.color.isEmpty ? Color.gray.opacity(0.15) : ColorPalette.from(item.color).color.opacity(0.15))
+                    .frame(width: 48, height: 48)
+                    .overlay {
+                        Image(systemName: "cube.box")
+                            .foregroundStyle(.secondary)
+                    }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(item.name)
+                        .font(.subheadline.weight(.medium))
+                    if item.isCheckedOut {
+                        Text("OUT")
+                            .font(.caption2.weight(.bold))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Theme.Colors.checkedOut.opacity(0.2))
+                            .foregroundStyle(Theme.Colors.checkedOut)
+                            .clipShape(Capsule())
+                    }
+                }
+
+                if !item.itemDescription.isEmpty {
+                    Text(item.itemDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                HStack(spacing: 8) {
+                    if let bin = item.bin {
+                        Label(bin.displayName, systemImage: "archivebox")
+                    }
+                    if let value = item.value {
+                        Label(CurrencyFormatter.format(value), systemImage: "dollarsign.circle")
+                    }
+                }
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+
+                if !item.tags.isEmpty {
+                    HStack(spacing: 4) {
+                        ForEach(item.tags.prefix(3), id: \.self) { tag in
+                            Text(tag)
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(.blue.opacity(0.1))
+                                .foregroundStyle(.blue)
+                                .clipShape(Capsule())
+                        }
+                        if item.tags.count > 3 {
+                            Text("+\(item.tags.count - 3)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct SearchBinRow: View {
+    let bin: Bin
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(bin.color.isEmpty ? Color.gray.opacity(0.15) : ColorPalette.from(bin.color).color.opacity(0.15))
+                .frame(width: 48, height: 48)
+                .overlay {
+                    Image(systemName: "archivebox")
+                        .foregroundStyle(bin.color.isEmpty ? .secondary : ColorPalette.from(bin.color).color)
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(bin.displayName)
+                    .font(.subheadline.weight(.medium))
+
+                HStack(spacing: 8) {
+                    Label("\(bin.items.count) items", systemImage: "cube.box")
+                    if let zone = bin.zone {
+                        Label(zone.name, systemImage: "square.grid.2x2")
+                    }
+                    if !bin.location.isEmpty {
+                        Label(bin.location, systemImage: "mappin")
+                    }
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a dedicated Search tab as the first tab in the app. Provides real-time search across all items and bins with rich results.

**Search results include:**
- Item photo thumbnails (or colored placeholder with icon)
- Description, bin location, value, and "OUT" badge
- Tag chips (up to 3 shown, +N overflow)
- Bin results with item count, zone, and location info

**Tag filtering:**
- Horizontal scrolling tag chips at the top of search
- Tap to toggle — multiple tags can be selected (OR logic)
- Clear-all button when filters are active
- Tags show even before typing a search query (browse by tag)

**"Checked Out" quick access:**
- When items are checked out, a badge link appears on the idle search screen
- Navigates to the full CheckedOutView

**Tab bar consolidation:**
- 5 tabs: Search, Bins, Zones, Scan, Settings
- Reports accessible from Settings (already linked)
- Checked Out accessible from Search idle state

## Test plan
- [ ] Search tab is the first tab, shows search bar + "Search Everything" prompt
- [ ] Typing filters items and bins in real-time
- [ ] Item results show thumbnails, descriptions, bin, value, tags
- [ ] Bin results show item count, zone, location
- [ ] Tag chips appear when items have tags — tapping filters results
- [ ] Multiple tag selection works (shows items matching ANY selected tag)
- [ ] Clear button resets tag filters
- [ ] "Checked Out" row appears when items are out, navigates correctly
- [ ] Tapping an item result navigates to ItemDetailView
- [ ] Tapping a bin result navigates to BinDetailView