### PR TITLE
feat: onboarding wizard with zone presets after household creation

### DIFF
--- a/binthere.xcodeproj/project.pbxproj
+++ b/binthere.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */; };
 		GG00000100000001AAAAAA01 /* CheckedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GG00000100000001BBBBBB01 /* CheckedOutView.swift */; };
 		HH00000100000001AAAAAA01 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = HH00000100000001BBBBBB01 /* SearchView.swift */; };
+		II00000100000001AAAAAA01 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = II00000100000001BBBBBB01 /* OnboardingView.swift */; };
 		FF00000100000001AAAAAA01 /* ReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000001BBBBBB01 /* ReportService.swift */; };
 		FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */; };
 		FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00000100000003BBBBBB01 /* ReportsView.swift */; };
@@ -150,6 +151,7 @@
 		EE00000100000005BBBBBB01 /* BulkValuationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkValuationSheet.swift; sourceTree = "<group>"; };
 		GG00000100000001BBBBBB01 /* CheckedOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckedOutView.swift; sourceTree = "<group>"; };
 		HH00000100000001BBBBBB01 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		II00000100000001BBBBBB01 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		FF00000100000001BBBBBB01 /* ReportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportService.swift; sourceTree = "<group>"; };
 		FF00000100000002BBBBBB01 /* AnalyticsDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDashboardView.swift; sourceTree = "<group>"; };
 		FF00000100000003BBBBBB01 /* ReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportsView.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				CC00000100000005CCCCCC01 /* Zones */,
 				FF00000100000004CCCCCC01 /* Reports */,
 				HH00000100000001CCCCCC01 /* Search */,
+				II00000100000001CCCCCC01 /* Onboarding */,
 				AA00000100000025CCCCCC01 /* Scanner */,
 				AA00000100000026CCCCCC01 /* Settings */,
 			);
@@ -324,6 +327,14 @@
 				HH00000100000001BBBBBB01 /* SearchView.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		II00000100000001CCCCCC01 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				II00000100000001BBBBBB01 /* OnboardingView.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		AA00000100000025CCCCCC01 /* Scanner */ = {
@@ -566,6 +577,7 @@
 				EE00000100000005AAAAAA01 /* BulkValuationSheet.swift in Sources */,
 				GG00000100000001AAAAAA01 /* CheckedOutView.swift in Sources */,
 				HH00000100000001AAAAAA01 /* SearchView.swift in Sources */,
+				II00000100000001AAAAAA01 /* OnboardingView.swift in Sources */,
 				FF00000100000001AAAAAA01 /* ReportService.swift in Sources */,
 				FF00000100000002AAAAAA01 /* AnalyticsDashboardView.swift in Sources */,
 				FF00000100000003AAAAAA01 /* ReportsView.swift in Sources */,

--- a/binthere/Views/Auth/AuthGateView.swift
+++ b/binthere/Views/Auth/AuthGateView.swift
@@ -7,6 +7,19 @@ struct AuthGateView: View {
     @State private var syncService = SyncService()
     @State private var householdService = HouseholdService()
     @State private var hasCheckedSession = false
+    @State private var showingOnboarding = false
+
+    private var hasCompletedOnboarding: Bool {
+        guard let userId = authService.currentUserId else { return true }
+        return UserDefaults.standard.bool(forKey: "onboarding_complete_\(userId)")
+    }
+
+    private func completeOnboarding() {
+        if let userId = authService.currentUserId {
+            UserDefaults.standard.set(true, forKey: "onboarding_complete_\(userId)")
+        }
+        showingOnboarding = false
+    }
 
     var body: some View {
         Group {
@@ -16,6 +29,8 @@ struct AuthGateView: View {
                 SignInView()
             } else if householdService.currentHousehold == nil && !householdService.isLoading {
                 HouseholdSetupView()
+            } else if householdService.currentHousehold != nil && showingOnboarding {
+                OnboardingView(onComplete: completeOnboarding)
             } else if householdService.currentHousehold != nil {
                 MainTabView()
             } else {
@@ -49,6 +64,9 @@ struct AuthGateView: View {
         }
         .onChange(of: householdService.currentHouseholdId) { _, newId in
             if !newId.isEmpty {
+                if !hasCompletedOnboarding {
+                    showingOnboarding = true
+                }
                 Task {
                     await syncService.syncAll(householdId: newId)
                     await syncService.subscribeToChanges(householdId: newId)

--- a/binthere/Views/Onboarding/OnboardingView.swift
+++ b/binthere/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,306 @@
+import SwiftUI
+import SwiftData
+
+struct OnboardingView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(HouseholdService.self) private var householdService
+    @Environment(SyncService.self) private var syncService
+
+    let onComplete: () -> Void
+
+    @State private var step: OnboardingStep = .welcome
+    @State private var selectedPresets: Set<String> = []
+    @State private var customZoneName = ""
+
+    enum OnboardingStep {
+        case welcome
+        case zones
+        case done
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Progress dots
+            HStack(spacing: 8) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(index <= stepIndex ? Color.accentColor : Color.gray.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                }
+            }
+            .padding(.top, 20)
+
+            TabView(selection: $step) {
+                welcomeStep
+                    .tag(OnboardingStep.welcome)
+
+                zonesStep
+                    .tag(OnboardingStep.zones)
+
+                doneStep
+                    .tag(OnboardingStep.done)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.easeInOut(duration: 0.3), value: step)
+        }
+    }
+
+    private var stepIndex: Int {
+        switch step {
+        case .welcome: return 0
+        case .zones: return 1
+        case .done: return 2
+        }
+    }
+
+    // MARK: - Welcome Step
+
+    private var welcomeStep: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "party.popper")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue.opacity(0.6))
+
+            Text("Welcome to binthere!")
+                .font(.title2.weight(.bold))
+
+            if let name = householdService.currentHousehold?.name {
+                Text("\"\(name)\" is ready to go.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("Let's set up some zones so you can organize your bins by location — like rooms, closets, or storage areas.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            Spacer()
+
+            VStack(spacing: 12) {
+                Button(action: { step = .zones }) {
+                    Text("Set Up Zones")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, minHeight: 20)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Skip for Now") {
+                    onComplete()
+                }
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 40)
+        }
+    }
+
+    // MARK: - Zones Step
+
+    private var zonesStep: some View {
+        VStack(spacing: 20) {
+            Text("Add Zones")
+                .font(.title2.weight(.bold))
+                .padding(.top, 20)
+
+            Text("Tap to select common zones, or add your own.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            ScrollView {
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                ], spacing: 12) {
+                    ForEach(ZonePreset.allPresets, id: \.name) { preset in
+                        ZonePresetCard(
+                            preset: preset,
+                            isSelected: selectedPresets.contains(preset.name)
+                        ) {
+                            if selectedPresets.contains(preset.name) {
+                                selectedPresets.remove(preset.name)
+                            } else {
+                                selectedPresets.insert(preset.name)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+
+                // Custom zone input
+                HStack {
+                    TextField("Custom zone name…", text: $customZoneName)
+                        .padding()
+                        .background(.quaternary)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    Button {
+                        let name = customZoneName.trimmingCharacters(in: .whitespaces)
+                        guard !name.isEmpty else { return }
+                        selectedPresets.insert(name)
+                        customZoneName = ""
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.title2)
+                    }
+                    .disabled(customZoneName.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+            }
+
+            VStack(spacing: 12) {
+                Button(action: {
+                    createSelectedZones()
+                    step = .done
+                }) {
+                    Text(selectedPresets.isEmpty
+                        ? "Continue Without Zones"
+                        : "Create \(selectedPresets.count) Zone\(selectedPresets.count == 1 ? "" : "s")")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, minHeight: 20)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Back") { step = .welcome }
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 20)
+        }
+    }
+
+    // MARK: - Done Step
+
+    private var doneStep: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 60))
+                .foregroundStyle(.green)
+
+            Text("You're All Set!")
+                .font(.title2.weight(.bold))
+
+            VStack(spacing: 8) {
+                if !selectedPresets.isEmpty {
+                    Text("Created \(selectedPresets.count) zone\(selectedPresets.count == 1 ? "" : "s").")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Start by adding your first bin — give it a label, pick a zone, and you're organizing.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+            }
+
+            Spacer()
+
+            Button(action: onComplete) {
+                Text("Get Started")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, minHeight: 20)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 40)
+            .padding(.bottom, 40)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func createSelectedZones() {
+        let householdId = householdService.currentHouseholdId
+        for presetName in selectedPresets {
+            let preset = ZonePreset.allPresets.first { $0.name == presetName }
+            let zone = Zone(
+                name: presetName,
+                locationDescription: preset?.description ?? "",
+                color: preset?.color ?? "",
+                icon: preset?.icon ?? ""
+            )
+            zone.householdId = householdId
+            zone.updatedAt = Date()
+            modelContext.insert(zone)
+        }
+        try? modelContext.save()
+
+        if !householdId.isEmpty {
+            Task {
+                let descriptor = FetchDescriptor<Zone>()
+                if let zones = try? modelContext.fetch(descriptor) {
+                    for zone in zones where zone.householdId == householdId {
+                        try? await syncService.pushZone(zone, householdId: householdId)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Zone Presets
+
+struct ZonePreset {
+    let name: String
+    let description: String
+    let icon: String
+    let color: String
+
+    static let allPresets: [Self] = [
+        Self(name: "Garage", description: "Tools, outdoor gear, automotive", icon: "car.fill", color: "orange"),
+        Self(name: "Kitchen", description: "Pantry, cabinets, drawers", icon: "fork.knife", color: "green"),
+        Self(name: "Bedroom", description: "Closets, under-bed storage", icon: "bed.double.fill", color: "blue"),
+        Self(name: "Living Room", description: "Shelves, entertainment center", icon: "sofa.fill", color: "purple"),
+        Self(name: "Basement", description: "Long-term storage, seasonal items", icon: "arrow.down.square.fill", color: "gray"),
+        Self(name: "Attic", description: "Holiday decorations, keepsakes", icon: "triangle.fill", color: "yellow"),
+        Self(name: "Office", description: "Supplies, electronics, files", icon: "desktopcomputer", color: "cyan"),
+        Self(name: "Bathroom", description: "Cabinets, under-sink storage", icon: "shower.fill", color: "teal"),
+        Self(name: "Closet", description: "Clothes, shoes, accessories", icon: "tshirt.fill", color: "pink"),
+        Self(name: "Storage Unit", description: "Off-site storage facility", icon: "building.2.fill", color: "brown"),
+        Self(name: "Shed", description: "Garden tools, outdoor equipment", icon: "house.fill", color: "mint"),
+        Self(name: "Workshop", description: "Power tools, workbench, supplies", icon: "wrench.and.screwdriver.fill", color: "red"),
+    ]
+}
+
+// MARK: - Preset Card
+
+private struct ZonePresetCard: View {
+    let preset: ZonePreset
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Image(systemName: preset.icon)
+                    .font(.title2)
+                    .foregroundStyle(isSelected ? .white : ColorPalette.from(preset.color).color)
+
+                Text(preset.name)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(isSelected ? .white : .primary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(isSelected
+                ? ColorPalette.from(preset.color).color
+                : ColorPalette.from(preset.color).color.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isSelected ? Color.clear : Color.gray.opacity(0.2), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -620,6 +620,59 @@ final class CodeGeneratorTests: XCTestCase {
     }
 }
 
+// MARK: - Onboarding Tests
+
+final class OnboardingTests: XCTestCase {
+
+    private let testUserId = "onboarding-test-user-\(UUID().uuidString)"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "onboarding_complete_\(testUserId)")
+    }
+
+    func test_onboardingNotComplete_byDefault() {
+        let key = "onboarding_complete_\(testUserId)"
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: key))
+    }
+
+    func test_onboardingComplete_persistsPerUser() {
+        let key = "onboarding_complete_\(testUserId)"
+        UserDefaults.standard.set(true, forKey: key)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: key))
+    }
+
+    func test_onboardingComplete_isolatedPerUser() {
+        let userA = "onboarding-test-A"
+        let userB = "onboarding-test-B"
+        defer {
+            UserDefaults.standard.removeObject(forKey: "onboarding_complete_\(userA)")
+            UserDefaults.standard.removeObject(forKey: "onboarding_complete_\(userB)")
+        }
+
+        UserDefaults.standard.set(true, forKey: "onboarding_complete_\(userA)")
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "onboarding_complete_\(userA)"))
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "onboarding_complete_\(userB)"))
+    }
+
+    func test_zonePresets_notEmpty() {
+        XCTAssertFalse(ZonePreset.allPresets.isEmpty)
+        XCTAssertGreaterThanOrEqual(ZonePreset.allPresets.count, 10)
+    }
+
+    func test_zonePresets_allHaveRequiredFields() {
+        for preset in ZonePreset.allPresets {
+            XCTAssertFalse(preset.name.isEmpty, "Preset name should not be empty")
+            XCTAssertFalse(preset.icon.isEmpty, "Preset \(preset.name) missing icon")
+            XCTAssertFalse(preset.color.isEmpty, "Preset \(preset.name) missing color")
+        }
+    }
+
+    func test_zonePresets_uniqueNames() {
+        let names = ZonePreset.allPresets.map(\.name)
+        XCTAssertEqual(names.count, Set(names).count, "Zone preset names should be unique")
+    }
+}
+
 // MARK: - QR Generator Tests
 
 final class QRGeneratorServiceTests: XCTestCase {


### PR DESCRIPTION
## Summary
New 3-step onboarding flow that appears after a user creates their first household:

1. **Welcome** — explains what zones are and why they matter
2. **Zone setup** — 12 preset zones in a tappable grid (Garage, Kitchen, Bedroom, Living Room, Basement, Attic, Office, Bathroom, Closet, Storage Unit, Shed, Workshop). Custom zone input field for anything else. Multi-select, batch create.
3. **Done** — confirmation + prompt to create first bin

**Key behaviors:**
- Skippable at every step ("Skip for Now" / "Continue Without Zones")
- Onboarding completion tracked per-user in UserDefaults — only shows once
- Created zones sync to Supabase immediately
- Progress dots show current step
- Existing users who already have a household are NOT shown onboarding

**Tests (6 new):**
- Onboarding state not complete by default
- Completion persists
- Isolated per user
- Zone presets non-empty, have required fields, unique names

## Test plan
- [ ] Create a new account → create household → onboarding wizard appears
- [ ] Welcome step: "Set Up Zones" advances, "Skip for Now" goes to app
- [ ] Zone step: tap presets to toggle, custom zone input works
- [ ] "Create N Zones" button creates all selected zones
- [ ] Done step: "Get Started" goes to MainTabView
- [ ] Sign out and back in — onboarding does NOT reappear
- [ ] Existing accounts — onboarding does NOT appear