### PR TITLE
feat: zone sub-locations (shelves, areas, spots)

### DIFF
--- a/binthere/Models/Zone.swift
+++ b/binthere/Models/Zone.swift
@@ -9,6 +9,7 @@ final class Zone {
     var locationDescription: String = ""
     var color: String = ""
     var icon: String = ""
+    var locations: [String] = []
     var updatedAt: Date = Date()
 
     @Relationship(deleteRule: .nullify, inverse: \Bin.zone)

--- a/binthere/Services/SyncService.swift
+++ b/binthere/Services/SyncService.swift
@@ -201,6 +201,7 @@ final class SyncService {
             "location_description": .string(zone.locationDescription),
             "color": .string(zone.color),
             "icon": .string(zone.icon),
+            "locations": .array(zone.locations.map { .string($0) }),
         ]
         try await client.from("zones").upsert(payload).execute()
         zone.updatedAt = Date()
@@ -292,6 +293,7 @@ final class SyncService {
                     existing.locationDescription = remote.locationDescription
                     existing.color = remote.color
                     existing.icon = remote.icon
+                    existing.locations = remote.locations
                     existing.updatedAt = remote.updatedAt
                 }
             } else {
@@ -299,6 +301,7 @@ final class SyncService {
                                 color: remote.color, icon: remote.icon)
                 zone.id = remote.id
                 zone.householdId = householdId
+                zone.locations = remote.locations
                 zone.updatedAt = remote.updatedAt
                 context.insert(zone)
             }
@@ -491,10 +494,11 @@ private struct RemoteZone: Decodable {
     let locationDescription: String
     let color: String
     let icon: String
+    let locations: [String]
     let updatedAt: Date
 
     enum CodingKeys: String, CodingKey {
-        case id, name, color, icon
+        case id, name, color, icon, locations
         case locationDescription = "location_description"
         case updatedAt = "updated_at"
     }

--- a/binthere/Views/Settings/ZoneDetailView.swift
+++ b/binthere/Views/Settings/ZoneDetailView.swift
@@ -9,6 +9,7 @@ struct ZoneDetailView: View {
     @State private var showingDeleteConfirmation = false
     @State private var showingAddBin = false
     @State private var showingBulkValuation = false
+    @State private var newLocationName = ""
 
     private var allItemsInZone: [Item] {
         zone.bins.flatMap(\.items)
@@ -73,6 +74,46 @@ struct ZoneDetailView: View {
                         Text("Icon")
                             .font(.subheadline)
                         IconPickerGrid(selectedIcon: $zone.icon)
+                    }
+                    .padding(.vertical, 4)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Locations")
+                            .font(.subheadline)
+                        Text("Shelves, areas, or spots within this zone")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        ForEach(zone.locations, id: \.self) { loc in
+                            HStack {
+                                Image(systemName: "mappin")
+                                    .foregroundStyle(.secondary)
+                                Text(loc)
+                                Spacer()
+                                Button {
+                                    zone.locations.removeAll { $0 == loc }
+                                    zone.updatedAt = Date()
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+
+                        HStack {
+                            TextField("Add location…", text: $newLocationName)
+                            Button {
+                                let name = newLocationName.trimmingCharacters(in: .whitespaces)
+                                guard !name.isEmpty else { return }
+                                zone.locations.append(name)
+                                zone.updatedAt = Date()
+                                newLocationName = ""
+                            } label: {
+                                Image(systemName: "plus.circle.fill")
+                            }
+                            .disabled(newLocationName.trimmingCharacters(in: .whitespaces).isEmpty)
+                        }
                     }
                     .padding(.vertical, 4)
                 }
@@ -158,6 +199,7 @@ private struct AddBinToZoneSheet: View {
     @State private var label = ""
     @State private var binDescription = ""
     @State private var location = ""
+    @State private var customLocation = ""
     @State private var selectedColor = ""
 
     var body: some View {
@@ -167,7 +209,21 @@ private struct AddBinToZoneSheet: View {
                     TextField("e.g. Garage Shelf, Junk Drawer", text: $label)
                 }
                 Section("Location") {
-                    TextField("Location (optional)", text: $location)
+                    if !zone.locations.isEmpty {
+                        Picker("Location", selection: $location) {
+                            Text("None").tag("")
+                            ForEach(zone.locations, id: \.self) { loc in
+                                Text(loc).tag(loc)
+                            }
+                            Divider()
+                            Text("Custom…").tag("__custom__")
+                        }
+                        if location == "__custom__" {
+                            TextField("Custom location", text: $customLocation)
+                        }
+                    } else {
+                        TextField("Location (optional)", text: $location)
+                    }
                 }
                 Section("Color") {
                     ColorPickerRow(selectedColor: $selectedColor)
@@ -193,12 +249,15 @@ private struct AddBinToZoneSheet: View {
     private func createBin() {
         let existingCodes = Set(allBins.map(\.code))
         let code = CodeGenerator.generateCode(existingCodes: existingCodes)
+        let resolvedLocation = location == "__custom__"
+            ? customLocation.trimmingCharacters(in: .whitespaces)
+            : location
 
         let bin = Bin(
             code: code,
             name: label.trimmingCharacters(in: .whitespaces),
             binDescription: binDescription,
-            location: location
+            location: resolvedLocation
         )
         bin.zone = zone
         bin.color = selectedColor

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -620,6 +620,85 @@ final class CodeGeneratorTests: XCTestCase {
     }
 }
 
+// MARK: - Zone Sub-Location Tests
+
+@MainActor
+final class ZoneSubLocationTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(
+            for: Zone.self, Bin.self, Item.self, CheckoutRecord.self, CustomAttribute.self,
+            configurations: config
+        )
+        context = container.mainContext
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+        context = nil
+    }
+
+    func test_zoneLocations_defaultsEmpty() {
+        let zone = Zone(name: "Garage")
+        XCTAssertTrue(zone.locations.isEmpty)
+    }
+
+    func test_zoneLocations_canAddLocations() throws {
+        let zone = Zone(name: "Garage")
+        zone.locations = ["Top Shelf", "Workbench", "Floor"]
+        context.insert(zone)
+        try context.save()
+
+        XCTAssertEqual(zone.locations.count, 3)
+        XCTAssertTrue(zone.locations.contains("Workbench"))
+    }
+
+    func test_zoneLocations_canRemoveLocation() throws {
+        let zone = Zone(name: "Kitchen")
+        zone.locations = ["Pantry", "Under Sink", "Top Cabinet"]
+        context.insert(zone)
+        try context.save()
+
+        zone.locations.removeAll { $0 == "Under Sink" }
+        try context.save()
+
+        XCTAssertEqual(zone.locations.count, 2)
+        XCTAssertFalse(zone.locations.contains("Under Sink"))
+    }
+
+    func test_binLocation_canMatchZoneLocation() throws {
+        let zone = Zone(name: "Garage")
+        zone.locations = ["Top Shelf", "Bottom Shelf"]
+        context.insert(zone)
+
+        let bin = Bin(code: "G001", location: "Top Shelf")
+        bin.zone = zone
+        context.insert(bin)
+        try context.save()
+
+        XCTAssertEqual(bin.location, "Top Shelf")
+        XCTAssertTrue(zone.locations.contains(bin.location))
+    }
+
+    func test_binLocation_canBeCustom() throws {
+        let zone = Zone(name: "Garage")
+        zone.locations = ["Top Shelf"]
+        context.insert(zone)
+
+        let bin = Bin(code: "G002", location: "Behind the door")
+        bin.zone = zone
+        context.insert(bin)
+        try context.save()
+
+        XCTAssertEqual(bin.location, "Behind the door")
+        XCTAssertFalse(zone.locations.contains(bin.location))
+    }
+}
+
 // MARK: - Ownership Tests
 
 @MainActor

--- a/supabase/migrations/006_zone_locations.sql
+++ b/supabase/migrations/006_zone_locations.sql
@@ -1,0 +1,5 @@
+-- 006_zone_locations.sql
+-- Adds a locations array to zones for sub-locations (shelves, areas, spots).
+-- Bins within a zone can select from these predefined locations.
+
+ALTER TABLE zones ADD COLUMN IF NOT EXISTS locations TEXT[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary
Zones can now define sub-locations — named spots like "Top Shelf", "Workbench", "Under Sink" — that bins can be assigned to.

**Zone model:** new \`locations: [String]\` field

**Zone Settings (ZoneDetailView):**
- Locations editor with add/remove in the Zone Settings disclosure group
- Each location shown with mappin icon and X to remove
- Text field + plus button to add new locations

**Bin creation (AddBinToZoneSheet):**
- When a zone has predefined locations, shows a Picker instead of free text
- Picker includes all zone locations + "None" + "Custom…" option
- "Custom…" reveals a free text field for unlisted locations
- When zone has no locations, falls back to the existing free text field

**Sync:** locations array pushed/pulled to Supabase as TEXT[]

**Migration:** \`supabase/migrations/006_zone_locations.sql\` — adds \`locations TEXT[] DEFAULT '{}'\` to zones table

## Test plan
- [ ] Apply migration 006 to Supabase
- [ ] Create a zone → add locations in Zone Settings
- [ ] Create a bin in that zone → location Picker shows zone's locations
- [ ] Select "Custom…" → free text field appears
- [ ] Zone with no locations → free text field (unchanged behavior)
- [ ] Remove a location from zone → disappears from list
- [ ] Sync → verify locations array in Supabase zones table
- [ ] All tests pass (\`Cmd+U\`)