### PR TITLE
feat: flexible space types (Home, Warehouse, Office, etc.)

### DIFF
--- a/binthere/Services/HouseholdService.swift
+++ b/binthere/Services/HouseholdService.swift
@@ -4,13 +4,52 @@ import Supabase
 struct Household: Codable, Identifiable {
     let id: UUID
     let name: String
+    let spaceType: String
     let createdBy: UUID
     let createdAt: Date
 
     enum CodingKeys: String, CodingKey {
         case id, name
+        case spaceType = "space_type"
         case createdBy = "created_by"
         case createdAt = "created_at"
+    }
+
+    var spaceTypeInfo: SpaceType {
+        SpaceType(rawValue: spaceType) ?? .home
+    }
+}
+
+enum SpaceType: String, CaseIterable, Identifiable {
+    case home
+    case warehouse
+    case office
+    case studio
+    case storageUnit = "storage_unit"
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .home: return "Home"
+        case .warehouse: return "Warehouse"
+        case .office: return "Office"
+        case .studio: return "Studio"
+        case .storageUnit: return "Storage Unit"
+        case .custom: return "Other"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .home: return "house.fill"
+        case .warehouse: return "building.2.fill"
+        case .office: return "building.fill"
+        case .studio: return "paintpalette.fill"
+        case .storageUnit: return "shippingbox.fill"
+        case .custom: return "square.grid.2x2.fill"
+        }
     }
 }
 
@@ -100,7 +139,8 @@ final class HouseholdService {
 
     // MARK: - Create Household
 
-    func createHousehold(name: String, userId: String, displayName: String) async {
+    func createHousehold(name: String, spaceType: SpaceType = .home,
+                         userId: String, displayName: String) async {
         isLoading = true
         error = nil
         defer { isLoading = false }
@@ -108,10 +148,10 @@ final class HouseholdService {
         do {
             let householdId = UUID()
 
-            // Create household — created_by defaults to auth.uid() via DB default
             let householdPayload: [String: AnyJSON] = [
                 "id": .string(householdId.uuidString.lowercased()),
                 "name": .string(name),
+                "space_type": .string(spaceType.rawValue),
                 "created_by": .string(userId),
             ]
 

--- a/binthere/Views/Household/HouseholdSetupView.swift
+++ b/binthere/Views/Household/HouseholdSetupView.swift
@@ -4,29 +4,46 @@ struct HouseholdSetupView: View {
     @Environment(AuthService.self) private var authService
     @Environment(HouseholdService.self) private var householdService
 
-    @State private var householdName = ""
+    @State private var spaceName = ""
     @State private var displayName = ""
+    @State private var selectedType: SpaceType = .home
     @State private var showingJoin = false
 
     var body: some View {
-        VStack(spacing: 32) {
+        VStack(spacing: 24) {
             Spacer()
 
-            Image(systemName: "house")
+            Image(systemName: selectedType.icon)
                 .font(.system(size: 60))
                 .foregroundStyle(.blue.opacity(0.6))
 
-            Text("Set Up Your Household")
+            Text("Create Your Space")
                 .font(.title2.weight(.bold))
 
-            Text("Create a household to start organizing your bins, or join an existing one with an invite code.")
+            Text("Set up a space to start organizing your bins, or join an existing one with an invite code.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 40)
 
             VStack(spacing: 12) {
-                TextField("Household Name (e.g. The Bennetts)", text: $householdName)
+                // Space type picker
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(SpaceType.allCases) { type in
+                            SpaceTypeCard(
+                                type: type,
+                                isSelected: selectedType == type
+                            ) {
+                                selectedType = type
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 40)
+                }
+                .padding(.horizontal, -40)
+
+                TextField(namePlaceholder, text: $spaceName)
                     .padding()
                     .background(.quaternary)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -37,18 +54,18 @@ struct HouseholdSetupView: View {
                     .background(.quaternary)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
 
-                Button(action: createHousehold) {
+                Button(action: createSpace) {
                     if householdService.isLoading {
                         ProgressView()
                             .frame(maxWidth: .infinity, minHeight: 20)
                     } else {
-                        Text("Create Household")
+                        Text("Create Space")
                             .font(.headline)
                             .frame(maxWidth: .infinity, minHeight: 20)
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(householdName.isEmpty || displayName.isEmpty || householdService.isLoading)
+                .disabled(spaceName.isEmpty || displayName.isEmpty || householdService.isLoading)
             }
             .padding(.horizontal, 40)
 
@@ -81,14 +98,48 @@ struct HouseholdSetupView: View {
         }
     }
 
-    private func createHousehold() {
+    private var namePlaceholder: String {
+        switch selectedType {
+        case .home: return "Space Name (e.g. The Bennetts)"
+        case .warehouse: return "Warehouse Name"
+        case .office: return "Office Name"
+        case .studio: return "Studio Name"
+        case .storageUnit: return "Storage Unit Name"
+        case .custom: return "Space Name"
+        }
+    }
+
+    private func createSpace() {
         guard let userId = authService.currentUserId else { return }
         Task {
             await householdService.createHousehold(
-                name: householdName,
+                name: spaceName,
+                spaceType: selectedType,
                 userId: userId,
                 displayName: displayName
             )
         }
+    }
+}
+
+private struct SpaceTypeCard: View {
+    let type: SpaceType
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                Image(systemName: type.icon)
+                    .font(.title3)
+                Text(type.displayName)
+                    .font(.caption2.weight(.medium))
+            }
+            .frame(width: 72, height: 64)
+            .background(isSelected ? Color.accentColor : Color.gray.opacity(0.1))
+            .foregroundStyle(isSelected ? .white : .primary)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/binthere/Views/Settings/SettingsView.swift
+++ b/binthere/Views/Settings/SettingsView.swift
@@ -42,7 +42,7 @@ struct SettingsView: View {
                 Text("This permanently deletes your account and all associated data. This cannot be undone.")
             }
 
-            Section("Household") {
+            Section("Space") {
                 if let household = householdService.currentHousehold {
                     NavigationLink {
                         HouseholdView()
@@ -50,19 +50,23 @@ struct SettingsView: View {
                         Label {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(household.name)
-                                Text("\(householdService.members.count) members")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 6) {
+                                    Text(household.spaceTypeInfo.displayName)
+                                    Text("·")
+                                    Text("\(householdService.members.count) members")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                             }
                         } icon: {
-                            Image(systemName: "house")
+                            Image(systemName: household.spaceTypeInfo.icon)
                         }
                     }
                     Button(action: { showingInvite = true }) {
                         Label("Invite Someone", systemImage: "person.badge.plus")
                     }
                 } else {
-                    Text("No household")
+                    Text("No space")
                         .foregroundStyle(.secondary)
                 }
             }

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -699,6 +699,45 @@ final class ZoneSubLocationTests: XCTestCase {
     }
 }
 
+// MARK: - Space Type Tests
+
+final class SpaceTypeTests: XCTestCase {
+
+    func test_allSpaceTypes_haveDisplayNames() {
+        for type in SpaceType.allCases {
+            XCTAssertFalse(type.displayName.isEmpty)
+        }
+    }
+
+    func test_allSpaceTypes_haveIcons() {
+        for type in SpaceType.allCases {
+            XCTAssertFalse(type.icon.isEmpty)
+        }
+    }
+
+    func test_allSpaceTypes_haveUniqueRawValues() {
+        let raw = SpaceType.allCases.map(\.rawValue)
+        XCTAssertEqual(raw.count, Set(raw).count)
+    }
+
+    func test_spaceType_defaultIsHome() {
+        XCTAssertEqual(SpaceType(rawValue: "home"), .home)
+    }
+
+    func test_spaceType_storageUnit() {
+        XCTAssertEqual(SpaceType(rawValue: "storage_unit"), .storageUnit)
+        XCTAssertEqual(SpaceType.storageUnit.displayName, "Storage Unit")
+    }
+
+    func test_spaceType_unknownFallsToNil() {
+        XCTAssertNil(SpaceType(rawValue: "spaceship"))
+    }
+
+    func test_spaceTypeCount() {
+        XCTAssertEqual(SpaceType.allCases.count, 6)
+    }
+}
+
 // MARK: - Ownership Tests
 
 @MainActor

--- a/supabase/migrations/007_space_type.sql
+++ b/supabase/migrations/007_space_type.sql
@@ -1,0 +1,5 @@
+-- 007_space_type.sql
+-- Adds a space_type column to households so users can create different
+-- kinds of spaces (home, warehouse, office, studio, storage unit, custom).
+
+ALTER TABLE households ADD COLUMN IF NOT EXISTS space_type TEXT NOT NULL DEFAULT 'home';


### PR DESCRIPTION
## Summary
Users can now pick what kind of space they're creating — no longer locked to "Household."

**6 space types:** Home, Warehouse, Office, Studio, Storage Unit, Other

**HouseholdSetupView redesign:**
- Horizontal scrolling type picker with icon cards
- Icon updates dynamically as you select a type
- Contextual placeholder text ("Warehouse Name", "Office Name", etc.)
- All labels say "Space" instead of "Household"

**Settings:**
- Space section shows type icon + type name alongside member count
- e.g. 🏠 "The Bennetts" — Home · 3 members

**Backend:**
- \`spaceType\` field on Household struct, sent as \`space_type\` to Supabase
- Migration 007 adds \`space_type TEXT DEFAULT 'home'\` — existing spaces default to "home"

**Tests (7 new):**
- All types have display names, icons, unique raw values
- Default, storage_unit, unknown fallback, count

## Test plan
- [ ] Apply migration 007 to Supabase
- [ ] New account → type picker appears on setup screen
- [ ] Each type shows correct icon and placeholder
- [ ] Create space with non-home type → Settings shows correct icon/label
- [ ] Existing accounts → default to "Home" type (migration default)
- [ ] All tests pass (\`Cmd+U\`)