### PR TITLE
feat: share AI provider + API key across household

### DIFF
--- a/binthere/Services/HouseholdService.swift
+++ b/binthere/Services/HouseholdService.swift
@@ -7,12 +7,16 @@ struct Household: Codable, Identifiable {
     let spaceType: String
     let createdBy: UUID
     let createdAt: Date
+    let aiProvider: String?
+    let apiKey: String?
 
     enum CodingKeys: String, CodingKey {
         case id, name
         case spaceType = "space_type"
         case createdBy = "created_by"
         case createdAt = "created_at"
+        case aiProvider = "ai_provider"
+        case apiKey = "api_key"
     }
 
     var spaceTypeInfo: SpaceType {
@@ -89,7 +93,11 @@ struct Invitation: Codable, Identifiable {
 
 @Observable
 final class HouseholdService {
-    var currentHousehold: Household?
+    var currentHousehold: Household? {
+        didSet {
+            ImageAnalysisService.setCurrentHousehold(currentHousehold)
+        }
+    }
     var members: [HouseholdMember] = []
     var pendingInvitations: [Invitation] = []
     var isLoading = false
@@ -99,6 +107,16 @@ final class HouseholdService {
 
     var currentHouseholdId: String {
         currentHousehold?.id.uuidString.lowercased() ?? ""
+    }
+
+    /// True when `userId` is an owner of the current household. Household
+    /// settings like the AI provider/key can only be written by owners per
+    /// the households RLS UPDATE policy.
+    func isOwner(userId: String) -> Bool {
+        members.contains { member in
+            member.role == "owner"
+                && member.userId.uuidString.lowercased() == userId.lowercased()
+        }
     }
 
     // MARK: - Load Current Household
@@ -132,8 +150,26 @@ final class HouseholdService {
             currentHousehold = households.first
             await loadMembers()
             await loadInvitations()
+            await migrateLegacyAPIKeyIfNeeded(userId: userId)
         } catch {
             self.error = error.localizedDescription
+        }
+    }
+
+    /// Moves a pre-8.x per-user API key from UserDefaults onto the
+    /// household record the first time an owner signs in after upgrade.
+    /// Silently does nothing for non-owners or when no legacy key exists.
+    private func migrateLegacyAPIKeyIfNeeded(userId: String) async {
+        guard let household = currentHousehold,
+              household.apiKey == nil,
+              isOwner(userId: userId),
+              let legacy = ImageAnalysisService.legacyLocalAPIKey() else { return }
+
+        let provider = AIProvider(rawValue: legacy.provider) ?? .anthropic
+        await updateAIConfig(apiKey: legacy.apiKey, provider: provider)
+
+        if currentHousehold?.apiKey == legacy.apiKey {
+            ImageAnalysisService.clearLegacyLocalAPIKey()
         }
     }
 
@@ -168,6 +204,51 @@ final class HouseholdService {
 
             // Reload
             await loadHousehold(userId: userId)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - AI Config
+
+    /// Updates the household-wide AI provider and/or API key.
+    /// Only the household owner can succeed here — non-owners will be
+    /// rejected by the households RLS UPDATE policy.
+    func updateAIConfig(apiKey: String?, provider: AIProvider) async {
+        guard let householdId = currentHousehold?.id.uuidString.lowercased() else {
+            error = "No household loaded."
+            return
+        }
+
+        let payload: [String: AnyJSON] = [
+            "api_key": apiKey.map { .string($0) } ?? .null,
+            "ai_provider": .string(provider.rawValue),
+        ]
+
+        do {
+            try await client.from("households")
+                .update(payload)
+                .eq("id", value: householdId)
+                .execute()
+            await refreshCurrentHousehold()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Re-fetches just the current household row (not members/invitations).
+    func refreshCurrentHousehold() async {
+        guard let householdId = currentHousehold?.id.uuidString.lowercased() else { return }
+
+        do {
+            let households: [Household] = try await client.from("households")
+                .select()
+                .eq("id", value: householdId)
+                .execute()
+                .value
+            if let refreshed = households.first {
+                currentHousehold = refreshed
+            }
         } catch {
             self.error = error.localizedDescription
         }

--- a/binthere/Services/ImageAnalysisService.swift
+++ b/binthere/Services/ImageAnalysisService.swift
@@ -54,19 +54,11 @@ enum AIProvider: String, CaseIterable, Identifiable {
         }
     }
 
-    private static var providerKey: String {
-        guard let userId = ImageAnalysisService.currentUserId else { return "ai_provider" }
-        return "ai_provider_\(userId)"
-    }
-
+    /// The provider currently in use for this household. Falls back to
+    /// `.anthropic` when no household is loaded or the column is unset.
     static var current: Self {
-        get {
-            let raw = UserDefaults.standard.string(forKey: providerKey) ?? "anthropic"
-            return Self(rawValue: raw) ?? .anthropic
-        }
-        set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: providerKey)
-        }
+        let raw = ImageAnalysisService.currentHousehold?.aiProvider ?? "anthropic"
+        return Self(rawValue: raw) ?? .anthropic
     }
 }
 
@@ -88,19 +80,61 @@ final class ImageAnalysisService {
     """
 
     static var currentUserId: String?
+    static var currentHousehold: Household?
+
+    /// Legacy per-user UserDefaults keys (read-only, used only for the
+    /// one-time migration to household-scoped storage).
+    private static let legacyGlobalApiKey = "claude_api_key"
+    private static let legacyGlobalProviderKey = "ai_provider"
+    private static func legacyUserApiKey(_ userId: String) -> String { "claude_api_key_\(userId)" }
+    private static func legacyUserProviderKey(_ userId: String) -> String { "ai_provider_\(userId)" }
 
     static func setCurrentUser(_ userId: String?) {
         currentUserId = userId
     }
 
-    private static var apiKeyKey: String {
-        guard let userId = currentUserId else { return "claude_api_key" }
-        return "claude_api_key_\(userId)"
+    static func setCurrentHousehold(_ household: Household?) {
+        currentHousehold = household
     }
 
+    /// Reads the shared household API key. Returns nil when no household
+    /// is loaded or the owner has not yet set one.
     static var apiKey: String? {
-        get { UserDefaults.standard.string(forKey: apiKeyKey) }
-        set { UserDefaults.standard.set(newValue, forKey: apiKeyKey) }
+        currentHousehold?.apiKey
+    }
+
+    /// Returns a legacy API key from UserDefaults if one exists, for the
+    /// one-time migration when a household is loaded for the first time.
+    /// Checks the current-user-scoped key first, then the global fallback.
+    static func legacyLocalAPIKey() -> (apiKey: String, provider: String)? {
+        let defaults = UserDefaults.standard
+        let apiKey: String?
+        let provider: String?
+
+        if let userId = currentUserId {
+            apiKey = defaults.string(forKey: legacyUserApiKey(userId))
+                ?? defaults.string(forKey: legacyGlobalApiKey)
+            provider = defaults.string(forKey: legacyUserProviderKey(userId))
+                ?? defaults.string(forKey: legacyGlobalProviderKey)
+        } else {
+            apiKey = defaults.string(forKey: legacyGlobalApiKey)
+            provider = defaults.string(forKey: legacyGlobalProviderKey)
+        }
+
+        guard let apiKey, !apiKey.isEmpty else { return nil }
+        return (apiKey, provider ?? "anthropic")
+    }
+
+    /// Clears any legacy per-user / global API key entries from UserDefaults
+    /// after a successful migration to household-scoped storage.
+    static func clearLegacyLocalAPIKey() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: legacyGlobalApiKey)
+        defaults.removeObject(forKey: legacyGlobalProviderKey)
+        if let userId = currentUserId {
+            defaults.removeObject(forKey: legacyUserApiKey(userId))
+            defaults.removeObject(forKey: legacyUserProviderKey(userId))
+        }
     }
 
     func analyzeImage(_ image: UIImage) async {

--- a/binthere/Views/Settings/SettingsView.swift
+++ b/binthere/Views/Settings/SettingsView.swift
@@ -7,14 +7,36 @@ struct SettingsView: View {
     @Environment(AuthService.self) private var authService
     @Environment(HouseholdService.self) private var householdService
     @Environment(SyncService.self) private var syncService
-    @State private var apiKey = ImageAnalysisService.apiKey ?? ""
+    @State private var apiKey = ""
     @State private var showingAPIKey = false
-    @State private var selectedProvider = AIProvider.current
+    @State private var selectedProvider: AIProvider = .anthropic
+    @State private var isSavingAIConfig = false
     @State private var showingDeleteConfirmation = false
     @State private var deleteError: String?
     @State private var notificationsEnabled = false
     @State private var showingInvite = false
     @State private var dailyOverdueCheck = false
+
+    private var canEditAIConfig: Bool {
+        guard let userId = authService.currentUserId else { return false }
+        return householdService.isOwner(userId: userId)
+    }
+
+    private var storedAPIKey: String {
+        householdService.currentHousehold?.apiKey ?? ""
+    }
+
+    private var storedProvider: AIProvider {
+        guard let raw = householdService.currentHousehold?.aiProvider,
+              let provider = AIProvider(rawValue: raw) else {
+            return .anthropic
+        }
+        return provider
+    }
+
+    private var hasUnsavedAIChanges: Bool {
+        apiKey != storedAPIKey || selectedProvider != storedProvider
+    }
 
     var body: some View {
         Form {
@@ -146,15 +168,13 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("AI Analysis") {
+            Section {
                 Picker("AI Provider", selection: $selectedProvider) {
                     ForEach(AIProvider.allCases) { provider in
                         Text(provider.displayName).tag(provider)
                     }
                 }
-                .onChange(of: selectedProvider) { _, newValue in
-                    AIProvider.current = newValue
-                }
+                .disabled(!canEditAIConfig || isSavingAIConfig)
 
                 HStack {
                     if showingAPIKey {
@@ -162,8 +182,10 @@ struct SettingsView: View {
                             .textContentType(.password)
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
+                            .disabled(!canEditAIConfig || isSavingAIConfig)
                     } else {
                         SecureField(apiKeyPlaceholder, text: $apiKey)
+                            .disabled(!canEditAIConfig || isSavingAIConfig)
                     }
                     Button(action: { showingAPIKey.toggle() }) {
                         Image(systemName: showingAPIKey ? "eye.slash" : "eye")
@@ -171,21 +193,41 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.plain)
                 }
-                .onChange(of: apiKey) { _, newValue in
-                    ImageAnalysisService.apiKey = newValue.isEmpty ? nil : newValue
-                }
 
-                Text(apiKeyHelpText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if canEditAIConfig {
+                    Button(action: saveAIConfig) {
+                        if isSavingAIConfig {
+                            ProgressView()
+                        } else {
+                            Label("Save", systemImage: "checkmark.circle")
+                        }
+                    }
+                    .disabled(!hasUnsavedAIChanges || isSavingAIConfig)
+                }
+            } header: {
+                Text("AI Analysis")
+            } footer: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(apiKeyHelpText)
+                    Text(aiConfigScopeText)
+                }
             }
 
             Section("About") {
-                LabeledContent("Version", value: "1.0.0")
+                LabeledContent("Version", value: appVersion)
                 LabeledContent("Built with", value: "SwiftUI + SwiftData")
             }
         }
         .navigationTitle("Settings")
+        .task {
+            syncAIConfigFromHousehold()
+        }
+        .onChange(of: householdService.currentHousehold?.apiKey) { _, _ in
+            syncAIConfigFromHousehold()
+        }
+        .onChange(of: householdService.currentHousehold?.aiProvider) { _, _ in
+            syncAIConfigFromHousehold()
+        }
         .sheet(isPresented: $showingInvite) {
             InviteMemberSheet()
         }
@@ -217,6 +259,35 @@ struct SettingsView: View {
         case .openai:
             return "Get a key at platform.openai.com/api-keys"
         }
+    }
+
+    private var aiConfigScopeText: String {
+        if canEditAIConfig {
+            return "Shared by everyone in your space. Only owners can change it."
+        }
+        return "Set by the space owner and shared with all members."
+    }
+
+    private func syncAIConfigFromHousehold() {
+        apiKey = storedAPIKey
+        selectedProvider = storedProvider
+    }
+
+    private func saveAIConfig() {
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let keyToSave = trimmed.isEmpty ? nil : trimmed
+        isSavingAIConfig = true
+        Task {
+            await householdService.updateAIConfig(apiKey: keyToSave, provider: selectedProvider)
+            syncAIConfigFromHousehold()
+            isSavingAIConfig = false
+        }
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "\(version) (\(build))"
     }
 
     private func wipeLocalData() {

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -1383,48 +1383,135 @@ final class AIJSONExtractionTests: XCTestCase {
     }
 }
 
-// MARK: - Per-User API Key Tests
+// MARK: - Household-Scoped API Key Tests
 
-final class PerUserAPIKeyTests: XCTestCase {
+final class HouseholdAPIKeyTests: XCTestCase {
+
+    private static let legacyGlobalKey = "claude_api_key"
+    private static let legacyGlobalProvider = "ai_provider"
+    private static let legacyUserAKey = "claude_api_key_user-aaa"
+    private static let legacyUserAProvider = "ai_provider_user-aaa"
 
     override func tearDown() {
-        // Clean up any keys we set during tests
-        UserDefaults.standard.removeObject(forKey: "claude_api_key_user-aaa")
-        UserDefaults.standard.removeObject(forKey: "claude_api_key_user-bbb")
-        UserDefaults.standard.removeObject(forKey: "claude_api_key")
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: Self.legacyGlobalKey)
+        defaults.removeObject(forKey: Self.legacyGlobalProvider)
+        defaults.removeObject(forKey: Self.legacyUserAKey)
+        defaults.removeObject(forKey: Self.legacyUserAProvider)
         ImageAnalysisService.setCurrentUser(nil)
+        ImageAnalysisService.setCurrentHousehold(nil)
     }
 
-    func test_apiKey_scopedPerUser() {
+    // MARK: apiKey read
+
+    func test_apiKey_nil_whenNoHouseholdLoaded() {
+        ImageAnalysisService.setCurrentHousehold(nil)
+        XCTAssertNil(ImageAnalysisService.apiKey)
+    }
+
+    func test_apiKey_readsFromCurrentHousehold() {
+        let household = Self.makeHousehold(apiKey: "sk-ant-household", provider: "anthropic")
+        ImageAnalysisService.setCurrentHousehold(household)
+        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-ant-household")
+    }
+
+    func test_apiKey_isSharedAcrossUsers() {
+        // Two different signed-in users in the same household see the same key.
+        let household = Self.makeHousehold(apiKey: "sk-shared", provider: "anthropic")
+        ImageAnalysisService.setCurrentHousehold(household)
+
         ImageAnalysisService.setCurrentUser("user-aaa")
-        ImageAnalysisService.apiKey = "sk-ant-aaa"
+        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-shared")
 
         ImageAnalysisService.setCurrentUser("user-bbb")
+        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-shared")
+    }
+
+    func test_apiKey_nil_whenHouseholdHasNoKey() {
+        let household = Self.makeHousehold(apiKey: nil, provider: "anthropic")
+        ImageAnalysisService.setCurrentHousehold(household)
         XCTAssertNil(ImageAnalysisService.apiKey)
-
-        ImageAnalysisService.apiKey = "sk-ant-bbb"
-        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-ant-bbb")
-
-        ImageAnalysisService.setCurrentUser("user-aaa")
-        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-ant-aaa")
     }
 
-    func test_apiKey_clearedOnSignOut() {
-        ImageAnalysisService.setCurrentUser("user-aaa")
-        ImageAnalysisService.apiKey = "sk-ant-test"
-        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-ant-test")
+    // MARK: AIProvider.current
 
-        ImageAnalysisService.setCurrentUser(nil)
-        // With no user, falls back to the un-scoped key
-        let fallbackKey = ImageAnalysisService.apiKey
-        XCTAssertNotEqual(fallbackKey, "sk-ant-test")
+    func test_provider_defaultsToAnthropic_whenNoHousehold() {
+        ImageAnalysisService.setCurrentHousehold(nil)
+        XCTAssertEqual(AIProvider.current, .anthropic)
     }
 
-    func test_apiKey_nilUserUsesFallbackKey() {
-        ImageAnalysisService.setCurrentUser(nil)
-        ImageAnalysisService.apiKey = "sk-fallback"
-        XCTAssertEqual(ImageAnalysisService.apiKey, "sk-fallback")
-        UserDefaults.standard.removeObject(forKey: "claude_api_key")
+    func test_provider_readsFromHousehold() {
+        let household = Self.makeHousehold(apiKey: "sk-openai", provider: "openai")
+        ImageAnalysisService.setCurrentHousehold(household)
+        XCTAssertEqual(AIProvider.current, .openai)
+    }
+
+    // MARK: Legacy migration helpers
+
+    func test_legacyLocalAPIKey_prefersUserScopedOverGlobal() {
+        UserDefaults.standard.set("sk-global", forKey: Self.legacyGlobalKey)
+        UserDefaults.standard.set("openai", forKey: Self.legacyGlobalProvider)
+        UserDefaults.standard.set("sk-user-a", forKey: Self.legacyUserAKey)
+        UserDefaults.standard.set("anthropic", forKey: Self.legacyUserAProvider)
+
+        ImageAnalysisService.setCurrentUser("user-aaa")
+        let legacy = ImageAnalysisService.legacyLocalAPIKey()
+
+        XCTAssertEqual(legacy?.apiKey, "sk-user-a")
+        XCTAssertEqual(legacy?.provider, "anthropic")
+    }
+
+    func test_legacyLocalAPIKey_fallsBackToGlobalWhenNoUserScopedKey() {
+        UserDefaults.standard.set("sk-global", forKey: Self.legacyGlobalKey)
+        UserDefaults.standard.set("openai", forKey: Self.legacyGlobalProvider)
+
+        ImageAnalysisService.setCurrentUser("user-aaa")
+        let legacy = ImageAnalysisService.legacyLocalAPIKey()
+
+        XCTAssertEqual(legacy?.apiKey, "sk-global")
+        XCTAssertEqual(legacy?.provider, "openai")
+    }
+
+    func test_legacyLocalAPIKey_nilWhenNothingStored() {
+        ImageAnalysisService.setCurrentUser("user-aaa")
+        XCTAssertNil(ImageAnalysisService.legacyLocalAPIKey())
+    }
+
+    func test_legacyLocalAPIKey_defaultsProviderToAnthropicWhenMissing() {
+        UserDefaults.standard.set("sk-only-key", forKey: Self.legacyUserAKey)
+        ImageAnalysisService.setCurrentUser("user-aaa")
+
+        XCTAssertEqual(ImageAnalysisService.legacyLocalAPIKey()?.provider, "anthropic")
+    }
+
+    func test_clearLegacyLocalAPIKey_removesBothScopedAndGlobalEntries() {
+        UserDefaults.standard.set("sk-user-a", forKey: Self.legacyUserAKey)
+        UserDefaults.standard.set("anthropic", forKey: Self.legacyUserAProvider)
+        UserDefaults.standard.set("sk-global", forKey: Self.legacyGlobalKey)
+        UserDefaults.standard.set("openai", forKey: Self.legacyGlobalProvider)
+
+        ImageAnalysisService.setCurrentUser("user-aaa")
+        ImageAnalysisService.clearLegacyLocalAPIKey()
+
+        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyUserAKey))
+        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyUserAProvider))
+        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyGlobalKey))
+        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyGlobalProvider))
+        XCTAssertNil(ImageAnalysisService.legacyLocalAPIKey())
+    }
+
+    // MARK: Helpers
+
+    private static func makeHousehold(apiKey: String?, provider: String) -> Household {
+        Household(
+            id: UUID(),
+            name: "Test Space",
+            spaceType: "home",
+            createdBy: UUID(),
+            createdAt: Date(),
+            aiProvider: provider,
+            apiKey: apiKey
+        )
     }
 }
 

--- a/binthereTests/binthereTests.swift
+++ b/binthereTests/binthereTests.swift
@@ -1386,54 +1386,37 @@ final class AIJSONExtractionTests: XCTestCase {
 // MARK: - Household-Scoped API Key Tests
 
 final class HouseholdAPIKeyTests: XCTestCase {
-
-    private static let legacyGlobalKey = "claude_api_key"
-    private static let legacyGlobalProvider = "ai_provider"
-    private static let legacyUserAKey = "claude_api_key_user-aaa"
-    private static let legacyUserAProvider = "ai_provider_user-aaa"
+    private static let globalKey = "claude_api_key"
+    private static let globalProv = "ai_provider"
+    private static let userKey = "claude_api_key_user-aaa"
+    private static let userProv = "ai_provider_user-aaa"
 
     override func tearDown() {
-        let defaults = UserDefaults.standard
-        defaults.removeObject(forKey: Self.legacyGlobalKey)
-        defaults.removeObject(forKey: Self.legacyGlobalProvider)
-        defaults.removeObject(forKey: Self.legacyUserAKey)
-        defaults.removeObject(forKey: Self.legacyUserAProvider)
+        [Self.globalKey, Self.globalProv, Self.userKey, Self.userProv]
+            .forEach { UserDefaults.standard.removeObject(forKey: $0) }
         ImageAnalysisService.setCurrentUser(nil)
         ImageAnalysisService.setCurrentHousehold(nil)
     }
 
-    // MARK: apiKey read
-
-    func test_apiKey_nil_whenNoHouseholdLoaded() {
+    func test_apiKey_nil_whenHouseholdMissingOrHasNoKey() {
         ImageAnalysisService.setCurrentHousehold(nil)
+        XCTAssertNil(ImageAnalysisService.apiKey)
+        ImageAnalysisService.setCurrentHousehold(Self.makeHousehold(apiKey: nil))
         XCTAssertNil(ImageAnalysisService.apiKey)
     }
 
     func test_apiKey_readsFromCurrentHousehold() {
-        let household = Self.makeHousehold(apiKey: "sk-ant-household", provider: "anthropic")
-        ImageAnalysisService.setCurrentHousehold(household)
+        ImageAnalysisService.setCurrentHousehold(Self.makeHousehold(apiKey: "sk-ant-household"))
         XCTAssertEqual(ImageAnalysisService.apiKey, "sk-ant-household")
     }
 
     func test_apiKey_isSharedAcrossUsers() {
-        // Two different signed-in users in the same household see the same key.
-        let household = Self.makeHousehold(apiKey: "sk-shared", provider: "anthropic")
-        ImageAnalysisService.setCurrentHousehold(household)
-
+        ImageAnalysisService.setCurrentHousehold(Self.makeHousehold(apiKey: "sk-shared"))
         ImageAnalysisService.setCurrentUser("user-aaa")
         XCTAssertEqual(ImageAnalysisService.apiKey, "sk-shared")
-
         ImageAnalysisService.setCurrentUser("user-bbb")
         XCTAssertEqual(ImageAnalysisService.apiKey, "sk-shared")
     }
-
-    func test_apiKey_nil_whenHouseholdHasNoKey() {
-        let household = Self.makeHousehold(apiKey: nil, provider: "anthropic")
-        ImageAnalysisService.setCurrentHousehold(household)
-        XCTAssertNil(ImageAnalysisService.apiKey)
-    }
-
-    // MARK: AIProvider.current
 
     func test_provider_defaultsToAnthropic_whenNoHousehold() {
         ImageAnalysisService.setCurrentHousehold(nil)
@@ -1441,77 +1424,58 @@ final class HouseholdAPIKeyTests: XCTestCase {
     }
 
     func test_provider_readsFromHousehold() {
-        let household = Self.makeHousehold(apiKey: "sk-openai", provider: "openai")
-        ImageAnalysisService.setCurrentHousehold(household)
+        ImageAnalysisService.setCurrentHousehold(Self.makeHousehold(apiKey: "sk", provider: "openai"))
         XCTAssertEqual(AIProvider.current, .openai)
     }
 
-    // MARK: Legacy migration helpers
-
     func test_legacyLocalAPIKey_prefersUserScopedOverGlobal() {
-        UserDefaults.standard.set("sk-global", forKey: Self.legacyGlobalKey)
-        UserDefaults.standard.set("openai", forKey: Self.legacyGlobalProvider)
-        UserDefaults.standard.set("sk-user-a", forKey: Self.legacyUserAKey)
-        UserDefaults.standard.set("anthropic", forKey: Self.legacyUserAProvider)
-
+        Self.seedDefaults([
+            Self.globalKey: "sk-global", Self.globalProv: "openai",
+            Self.userKey: "sk-user-a", Self.userProv: "anthropic",
+        ])
         ImageAnalysisService.setCurrentUser("user-aaa")
         let legacy = ImageAnalysisService.legacyLocalAPIKey()
-
         XCTAssertEqual(legacy?.apiKey, "sk-user-a")
         XCTAssertEqual(legacy?.provider, "anthropic")
     }
 
     func test_legacyLocalAPIKey_fallsBackToGlobalWhenNoUserScopedKey() {
-        UserDefaults.standard.set("sk-global", forKey: Self.legacyGlobalKey)
-        UserDefaults.standard.set("openai", forKey: Self.legacyGlobalProvider)
-
+        Self.seedDefaults([Self.globalKey: "sk-global", Self.globalProv: "openai"])
         ImageAnalysisService.setCurrentUser("user-aaa")
         let legacy = ImageAnalysisService.legacyLocalAPIKey()
-
         XCTAssertEqual(legacy?.apiKey, "sk-global")
         XCTAssertEqual(legacy?.provider, "openai")
     }
 
-    func test_legacyLocalAPIKey_nilWhenNothingStored() {
+    func test_legacyLocalAPIKey_nilWhenEmpty_andDefaultsProviderToAnthropic() {
         ImageAnalysisService.setCurrentUser("user-aaa")
         XCTAssertNil(ImageAnalysisService.legacyLocalAPIKey())
-    }
-
-    func test_legacyLocalAPIKey_defaultsProviderToAnthropicWhenMissing() {
-        UserDefaults.standard.set("sk-only-key", forKey: Self.legacyUserAKey)
-        ImageAnalysisService.setCurrentUser("user-aaa")
-
+        UserDefaults.standard.set("sk-only-key", forKey: Self.userKey)
         XCTAssertEqual(ImageAnalysisService.legacyLocalAPIKey()?.provider, "anthropic")
     }
 
     func test_clearLegacyLocalAPIKey_removesBothScopedAndGlobalEntries() {
-        UserDefaults.standard.set("sk-user-a", forKey: Self.legacyUserAKey)
-        UserDefaults.standard.set("anthropic", forKey: Self.legacyUserAProvider)
-        UserDefaults.standard.set("sk-global", forKey: Self.legacyGlobalKey)
-        UserDefaults.standard.set("openai", forKey: Self.legacyGlobalProvider)
-
+        Self.seedDefaults([
+            Self.userKey: "sk-user-a", Self.userProv: "anthropic",
+            Self.globalKey: "sk-global", Self.globalProv: "openai",
+        ])
         ImageAnalysisService.setCurrentUser("user-aaa")
         ImageAnalysisService.clearLegacyLocalAPIKey()
-
-        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyUserAKey))
-        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyUserAProvider))
-        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyGlobalKey))
-        XCTAssertNil(UserDefaults.standard.string(forKey: Self.legacyGlobalProvider))
+        let defaults = UserDefaults.standard
+        XCTAssertNil(defaults.string(forKey: Self.userKey))
+        XCTAssertNil(defaults.string(forKey: Self.userProv))
+        XCTAssertNil(defaults.string(forKey: Self.globalKey))
+        XCTAssertNil(defaults.string(forKey: Self.globalProv))
         XCTAssertNil(ImageAnalysisService.legacyLocalAPIKey())
     }
 
-    // MARK: Helpers
+    private static func seedDefaults(_ entries: [String: String]) {
+        entries.forEach { UserDefaults.standard.set($0.value, forKey: $0.key) }
+    }
 
-    private static func makeHousehold(apiKey: String?, provider: String) -> Household {
-        Household(
-            id: UUID(),
-            name: "Test Space",
-            spaceType: "home",
-            createdBy: UUID(),
-            createdAt: Date(),
-            aiProvider: provider,
-            apiKey: apiKey
-        )
+    private static func makeHousehold(apiKey: String?, provider: String = "anthropic") -> Household {
+        Household(id: UUID(), name: "Test", spaceType: "home", createdBy: UUID(),
+                  createdAt: Date(), aiProvider: provider, apiKey: apiKey)
     }
 }
 

--- a/supabase/migrations/008_household_ai_config.sql
+++ b/supabase/migrations/008_household_ai_config.sql
@@ -1,0 +1,9 @@
+-- 008_household_ai_config.sql
+-- Moves the AI provider + API key from per-user UserDefaults to a shared
+-- household-scoped config. One key + one provider per household; all
+-- members can read (via the existing "Members can view their households"
+-- SELECT policy), only owners can write (via the existing "Owners can
+-- update their households" UPDATE policy).
+
+ALTER TABLE households ADD COLUMN IF NOT EXISTS ai_provider TEXT NOT NULL DEFAULT 'anthropic';
+ALTER TABLE households ADD COLUMN IF NOT EXISTS api_key TEXT;


### PR DESCRIPTION
## Summary
Moves the Claude / OpenAI API key and provider choice off per-user `UserDefaults` and onto the `households` row in Supabase so everyone in a household uses the same key. Previously each member had to paste their own key on every device they signed in to.

- New migration `008_household_ai_config.sql` adds `api_key` and `ai_provider` columns to `households`. No new RLS work needed — the existing `Members can view their households` SELECT policy and `Owners can update their households` UPDATE policy already gate access correctly.
- `HouseholdService` gains `updateAIConfig(apiKey:provider:)`, `refreshCurrentHousehold()`, and `isOwner(userId:)`. Setting `currentHousehold` propagates to `ImageAnalysisService` via a `didSet` so the AI services pick up changes automatically.
- `ImageAnalysisService.apiKey` and `AIProvider.current` now read from the loaded household. The legacy per-user UserDefaults entries are still readable through `legacyLocalAPIKey()` solely so we can do the **one-time migration**: when an owner signs in for the first time after upgrade and the household has no key yet, their old local key gets promoted onto the household and the local copies are cleared.
- `SettingsView` shows the AI section as read-only for non-owners (with a "Set by the space owner" note) and gives owners an explicit **Save** button instead of writing on every keystroke.

## Decisions worth flagging
- **Owner-only writes.** The existing households RLS already restricts UPDATE to the owner role, so non-owners attempting to save would just hit an RLS rejection. I matched that — UI is disabled for non-owners. If you'd rather any household member be able to update the key, we'd need a `SECURITY DEFINER` RPC that allows write access to just these two columns; happy to follow up with that variant.
- **Plaintext in Supabase.** The key sits unencrypted in the `households` row. That's no worse than the current state (plaintext in `UserDefaults`), and gated to household members via RLS, but it's still in violation of the Keychain guidance in CLAUDE.md. Treating that as a separate cleanup PR rather than scoping it in here.

## Test plan
- [x] New unit test class `HouseholdAPIKeyTests` (11 cases) covering: nil-when-no-household, household-scoped reads, sharing across users, provider read, legacy migration helpers (user-scoped vs global precedence, defaults, clearing). All passing on iPhone 17 simulator.
- [x] Full `binthereTests` suite passes locally.
- [ ] Manual: owner pastes a key → both members see AI estimation work without further setup.
- [ ] Manual: non-owner sees the AI section as read-only with the "Set by the space owner" note.
- [ ] Manual on a device with a pre-existing per-user key in UserDefaults: sign in as the owner → key auto-promotes onto the household and the local copy is cleared. Same scenario as a non-owner: their local key is left in place (silently fails to migrate, which is correct — they can't write the household).
- [ ] Apply migration `008_household_ai_config.sql` against the Supabase project before this ships.